### PR TITLE
fix: corrige links quebrados, migrados e soft-404

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Cada fase tem um **teste de saída** — a condição objetiva para avançar. N�
 
 Oito arquivos, um por área. Todo curso vem marcado com:
 
-`🇧🇷` português · `🇺🇸` inglês · `🆓` gratuito · `🎓` emite certificado · `🧪` prático · `⭐` prioridade alta
+`🇧🇷` português · `🇺🇸` inglês · `🆓` gratuito · `💸` pago · `🎓` emite certificado · `🧪` prático · `⭐` prioridade alta
 
 Se você quer só material em português, existe um atalho: [`docs/trilha-pt-br.md`](./docs/trilha-pt-br.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ You cannot secure what you don't understand. Skip this only if you already admin
 |---|---|---|---|---|
 | 0.1 | Networking basics (OSI, TCP/IP, DNS, DHCP, routing) | [Cisco Networking Basics](https://www.netacad.com/courses/networking-basics) | 20 | ✅ Badge |
 | 0.2 | Intro to Cybersecurity | [Cisco Intro to Cybersecurity](https://www.netacad.com/courses/introduction-to-cybersecurity) | 6 | ✅ Badge |
-| 0.3 | Linux command line | [TryHackMe Pre-Security path](https://tryhackme.com/path/outline/presecurity) (free rooms) + [Linux Journey](https://linuxjourney.com/) | 20 | ⚪ |
+| 0.3 | Linux command line | [TryHackMe Pre-Security path](https://tryhackme.com/path/outline/presecurity) (free rooms) + [Linux Journey](https://labex.io/linuxjourney) | 20 | ⚪ |
 | 0.4 | Windows internals + AD basics | [Microsoft Learn — Windows Server fundamentals](https://learn.microsoft.com/training/) | 12 | ⚪ |
 | 0.5 | Threat landscape awareness | [Fortinet NSE 1 + 2 + 3](https://training.fortinet.com/) | 6 | ✅ 3 badges |
 | 0.6 | Build a home lab | VirtualBox/Proxmox + Kali + Ubuntu + Windows eval VMs | 6 | ⚪ |
@@ -90,7 +90,7 @@ Pick **one** primary track now. You said all four interest you — that's fine, 
 |---|---|---|---|
 | Azure security ops (SC-200 path) | [Microsoft Learn](https://learn.microsoft.com/training/) | 35 | ✅ Free |
 | AWS security fundamentals + labs | [AWS Skill Builder](https://skillbuilder.aws/) free tier + Builder Labs | 30 | ✅ Free tier |
-| GCP security badges | [Google Cloud Skills Boost](https://www.cloudskillsboost.google/) free courses | 25 | ✅ Free tier |
+| GCP security badges | [Google Skills](https://www.skills.google/) free courses | 25 | ✅ Free tier |
 | Cloud attack/defense practice | [flaws.cloud](http://flaws.cloud/) + [flaws2.cloud](http://flaws2.cloud/) + [CloudGoat](https://github.com/RhinoSecurityLabs/cloudgoat) | 20 | ✅ Free |
 | IaC + container security | [Kubernetes Goat](https://madhuakula.com/kubernetes-goat/) | 10 | ✅ Free |
 
@@ -100,7 +100,7 @@ Pick **one** primary track now. You said all four interest you — that's fine, 
 |---|---|---|---|
 | NIST Cybersecurity Framework 2.0 | [NIST CSF official resources](https://www.nist.gov/cyberframework) | 20 | ✅ Free |
 | NIST RMF + SP 800-53 | [NIST RMF training](https://csrc.nist.gov/projects/risk-management/rmf-courses) | 20 | ✅ Free |
-| Federal/critical-infra courses | [CISA free training](https://www.cisa.gov/resources-tools/training) + [FEMA IS courses](https://training.fema.gov/is/) | 20 | ✅ Free + certs |
+| Federal/critical-infra courses | [CISA free training](https://www.cisa.gov/resources-tools/training) + [FEMA IS courses](https://training.fema.gov/programs/independent-study/) | 20 | ✅ Free + certs |
 | ISO 27001 structure | [ISO 27001 overview material](https://www.iso.org/standard/27001) + free vendor webinars | 15 | ✅ Free |
 | Risk & audit practice | Build a real risk register + control matrix for a fake company | 15 | ✅ Free |
 

--- a/cursos/00-fundamentos.md
+++ b/cursos/00-fundamentos.md
@@ -8,9 +8,9 @@
 |---|---|---|---|
 | ⭐ Primeiros Passos em Tecnologia | [Fundação Bradesco](https://www.ev.org.br/trilhas-de-conhecimento/primeiros-passos-em-tecnologia) | 🇧🇷 | 🆓 🎓 |
 | Fundamentos de TI: Hardware e Software | [Fundação Bradesco](https://www.ev.org.br/cursos/fundamentos-de-ti-hardware-e-software) | 🇧🇷 | 🆓 🎓 |
-| Linux Fundamentos | [FIAP / Eu Capacito](https://www.eucapacito.com.br/curso-ec/linux-fundamentos/) | 🇧🇷 | 🆓 🎓 |
-| ⭐ Linux 100: Fundamentals | [TCM Security](https://academy.tcm-sec.com/p/linux-fundamentals) | 🇺🇸 | 🆓 🎓 |
-| Linux Journey | [linuxjourney.com](https://linuxjourney.com/) | 🇺🇸 | 🆓 🧪 |
+| Linux Fundamentos | [FIAP / Eu Capacito](https://www.eucapacito.com.br/cursos/linux-fundamentos/) | 🇧🇷 | 🆓 🎓 |
+| ⭐ Linux 100: Fundamentals | [TCM Security](https://tcm-sec.com/academy/linux-100-fundamentals/) | 🇺🇸 | 🆓 🎓 |
+| Linux Journey | [labex.io/linuxjourney](https://labex.io/linuxjourney) | 🇺🇸 | 🆓 🧪 |
 | OverTheWire — Bandit (Linux via wargame) | [overthewire.org](https://overthewire.org/wargames/bandit/) | 🇺🇸 | 🆓 🧪 |
 | Introdução ao Linux | [Escola Virtual Gov](https://www.escolavirtual.gov.br/) | 🇧🇷 | 🆓 🎓 |
 | Windows Server fundamentals | [Microsoft Learn](https://learn.microsoft.com/training/) | 🇺🇸🇧🇷 | 🆓 |
@@ -25,7 +25,7 @@
 | Dispositivos de Rede e Configuração Inicial | [Cisco NetAcad](https://www.netacad.com/pt/courses/networking-devices-and-initial-configuration) | 🇧🇷 | 🆓 🎓 |
 | Introdução à IoT e Transformação Digital | [Cisco NetAcad](https://www.netacad.com/pt/courses/introduction-iot) | 🇧🇷 | 🆓 🎓 |
 | Network Basics | [Cybrary](https://app.cybrary.it/browse/course/network-fundamentals-v2) | 🇺🇸 | 🆓 🎓 |
-| Fundamentals of Network Security | [Palo Alto Networks](https://www.paloaltonetworks.com/cyberpedia/free-cybersecurity-education-courses) | 🇺🇸 | 🆓 |
+| Fundamentals of Network Security | [Palo Alto Beacon](https://learn.paloaltonetworks.com/) | 🇺🇸 | 🆓 |
 | Computer Networks: A Systems Approach | [book.systemsapproach.org](https://book.systemsapproach.org/) | 🇺🇸 | 🆓 |
 | Wireshark — tutoriais oficiais | [wireshark.org](https://www.wireshark.org/docs/) | 🇺🇸 | 🆓 🧪 |
 | Practical Networking (série completa) | [practicalnetworking.net](https://www.practicalnetworking.net/) | 🇺🇸 | 🆓 |
@@ -36,16 +36,16 @@
 |---|---|---|---|
 | ⭐ CS50: Introduction to Computer Science | [Harvard](https://cs50.harvard.edu/x/) | 🇺🇸 | 🆓 🎓 |
 | ⭐ CC50 (CS50 em português) | [Fundação Estudar](https://materiais.napratica.org.br/cc50) | 🇧🇷 | 🆓 🎓 |
-| Python Básico | [Solyd](https://solyd.com.br/treinamentos/python-basico/) | 🇧🇷 | 🆓 🎓 |
+| Python Básico | [Solyd](https://solyd.com.br/cursos/python-basico/) | 🇧🇷 | 🆓 🎓 |
 | Fundamentos do Python 1 | [Cisco NetAcad](https://www.netacad.com/pt/courses/python-essentials-1) | 🇧🇷 | 🆓 🎓 |
 | Linguagem de Programação Python — Básico | [Fundação Bradesco](https://www.ev.org.br/cursos/linguagem-de-programacao-python-basico) | 🇧🇷 | 🆓 🎓 |
 | Aprendendo com Python | [Escola Virtual Gov](https://www.escolavirtual.gov.br/curso/629) | 🇧🇷 | 🆓 🎓 |
 | Curso em Vídeo — Python | [cursoemvideo.com](https://www.cursoemvideo.com/) | 🇧🇷 | 🆓 🎓 |
-| Programming 100: Fundamentals | [TCM Security](https://academy.tcm-sec.com/p/programming-100-fundamentals) | 🇺🇸 | 🆓 🎓 |
+| Programming 100: Fundamentals | [TCM Security](https://tcm-sec.com/academy/programming-100-fundamentals/) | 🇺🇸 | 🆓 🎓 |
 | Intro to Python | [Cybrary](https://app.cybrary.it/browse/course/python) | 🇺🇸 | 🆓 🎓 |
 | Automate the Boring Stuff with Python | [automatetheboringstuff.com](https://automatetheboringstuff.com/) | 🇺🇸 | 🆓 |
 | Crie um site com HTML, CSS e JavaScript | [Fundação Bradesco](https://www.ev.org.br/cursos/crie-um-site-simples-usando-html-css-e-javascript) | 🇧🇷 | 🆓 🎓 |
-| Primeiros Passos para Desenvolvimento Web | [DIO](https://web.dio.me/course/primeiros-passos-para-desenvolvimento-web/) | 🇧🇷 | 🆓 🎓 |
+| Curso de HTML5 e CSS3 (módulo 1) | [Curso em Vídeo](https://www.cursoemvideo.com/curso/html5-css3-modulo1/) | 🇧🇷 | 🆓 🎓 |
 | Java Development / Python Development / Android | [FIAP / Eu Capacito](https://www.eucapacito.com.br/cursos/) | 🇧🇷 | 🆓 🎓 |
 | ⭐ Curso de Programação em C | [Mente Binária](https://www.mentebinaria.com.br/cursos/) | 🇧🇷 | 🆓 🎓 |
 

--- a/cursos/01-introducao-seguranca.md
+++ b/cursos/01-introducao-seguranca.md
@@ -12,7 +12,7 @@
 | Segurança da Informação para Todos | [Escola Virtual Gov](https://www.escolavirtual.gov.br/curso/1256) | 🇧🇷 | 🆓 🎓 |
 | Fundamentos de Seg. da Informação na Transformação Digital | [Escola Virtual Gov](https://www.escolavirtual.gov.br/curso/916) | 🇧🇷 | 🆓 🎓 |
 | Segurança de Endpoint | [Cisco NetAcad](https://www.netacad.com/pt/courses/endpoint-security) | 🇧🇷 | 🆓 🎓 |
-| ⭐ Practical Security Fundamentals | [TCM Security](https://academy.tcm-sec.com/p/practical-security-fundamentals) | 🇺🇸 | 🆓 🎓 |
+| ⭐ Practical Security Fundamentals | [TCM Security](https://tcm-sec.com/academy/practical-security-fundamentals/) | 🇺🇸 | 🆓 🎓 |
 | ⭐ Professor Messer — Security+ (curso completo) | [professormesser.com](https://www.professormesser.com/) | 🇺🇸 | 🆓 |
 | Google Cybersecurity Professional Certificate | [Coursera](https://www.coursera.org/professional-certificates/google-cybersecurity) | 🇺🇸 (leg. 🇧🇷) | 🆓 via Financial Aid 🎓 |
 | Cybersecurity Fundamentals | [IBM SkillsBuild](https://skillsbuild.org/) | 🇺🇸 | 🆓 🎓 |
@@ -20,7 +20,7 @@
 | FCA — Fortinet Certified Associate | [Fortinet](https://training.fortinet.com/) | 🇺🇸 | 🆓 🎓 |
 | Entry-Level Cybersecurity Training | [Cybrary](https://app.cybrary.it/browse/course/entry-level-cybersecurity-training) | 🇺🇸 | 🆓 🎓 |
 | Cybersecurity Basics | [Cybrary](https://app.cybrary.it/browse/course/cybersecurity-fundamentals) | 🇺🇸 | 🆓 🎓 |
-| Introduction to Cybersecurity | [Palo Alto Networks](https://www.paloaltonetworks.com/cyberpedia/free-cybersecurity-education-courses) | 🇺🇸 | 🆓 |
+| Introduction to Cybersecurity | [Palo Alto Beacon](https://learn.paloaltonetworks.com/) | 🇺🇸 | 🆓 |
 | SC-900: Security, Compliance & Identity Fundamentals | [Microsoft Learn](https://learn.microsoft.com/training/) | 🇺🇸🇧🇷 | 🆓 |
 | Pre-Security Path | [TryHackMe](https://tryhackme.com/path/outline/presecurity) | 🇺🇸 | 🆓 parcial 🧪 |
 | MITRE ATT&CK Training | [attack.mitre.org](https://attack.mitre.org/resources/training/) | 🇺🇸 | 🆓 |

--- a/cursos/02-blue-team.md
+++ b/cursos/02-blue-team.md
@@ -7,15 +7,15 @@
 | Curso | Provedor | Lang | Tags |
 |---|---|---|---|
 | ⭐ SOC Level 1 Path | [TryHackMe](https://tryhackme.com/path/outline/soclevel1) | 🇺🇸 | 🆓 parcial 🧪 🎓 |
-| ⭐ Blue Team Junior Analyst Pathway | [Security Blue Team](https://www.securityblue.team/courses/blue-team-junior-analyst-pathway-bundle) | 🇺🇸 | 🆓 🎓 |
+| ⭐ Blue Team Junior Analyst Pathway | [Centri (ex-Security Blue Team)](https://www.centri.org/courses/blue-team-junior-analyst-pathway-bundle) | 🇺🇸 | 🆓 🎓 |
 | ⭐ Splunk Free Courses (Fundamentals 1) | [Splunk](https://www.splunk.com/en_us/training/free-courses/overview.html) | 🇺🇸 | 🆓 🎓 |
-| Fundamentals of SOC | [Palo Alto Networks](https://www.paloaltonetworks.com/cyberpedia/free-cybersecurity-education-courses) | 🇺🇸 | 🆓 |
+| Fundamentals of SOC | [Palo Alto Beacon](https://learn.paloaltonetworks.com/) | 🇺🇸 | 🆓 |
 | Defensive Security Operations | [Cybrary](https://app.cybrary.it/browse/course/defensive-security-operations) | 🇺🇸 | 🆓 🎓 |
 | Defensive Security and Cyber Risk | [Cybrary](https://app.cybrary.it/browse/course/defensive-security-and-cyber-risk) | 🇺🇸 | 🆓 🎓 |
 | Digital Forensics Basics | [Cybrary](https://app.cybrary.it/browse/course/digital-forensics-basics) | 🇺🇸 | 🆓 🎓 |
 | SC-200: Security Operations Analyst path | [Microsoft Learn](https://learn.microsoft.com/training/) | 🇺🇸🇧🇷 | 🆓 |
-| ICS300 — Industrial Control System Cybersecurity | [Idaho National Laboratory](https://ics-training.inl.gov/) | 🇺🇸 | 🆓 🎓 |
-| Elastic Security / ELK free training | [elastic.co](https://www.elastic.co/training/free) | 🇺🇸 | 🆓 |
+| ICS300 — Industrial Control System Cybersecurity | [Idaho National Laboratory](https://ics-training.inl.gov/learn) | 🇺🇸 | 🆓 🎓 |
+| Elastic Security / ELK free training | [elastic.co](https://www.elastic.co/training) | 🇺🇸 | 🆓 |
 | Wazuh — documentação e cursos | [wazuh.com](https://wazuh.com/) | 🇺🇸 | 🆓 🧪 |
 | Security Onion — treinamento gratuito | [securityonion.net](https://securityonionsolutions.com/training) | 🇺🇸 | 🆓 |
 | Velociraptor DFIR training | [docs.velociraptor.app](https://docs.velociraptor.app/training/) | 🇺🇸 | 🆓 |

--- a/cursos/03-red-team.md
+++ b/cursos/03-red-team.md
@@ -6,15 +6,15 @@
 
 | Curso | Provedor | Lang | Tags |
 |---|---|---|---|
-| ⭐ Introdução ao Hacking e Pentest 2.0 | [Solyd](https://solyd.com.br/treinamentos/introducao-ao-hacking-e-pentest-2/) | 🇧🇷 | 🆓 🎓 |
+| ⭐ Introdução ao Hacking e Pentest 2.0 | [Solyd](https://solyd.com.br/cursos/introducao-ao-hacking-e-pentest-2/) | 🇧🇷 | 🆓 🎓 |
 | ⭐ Introdução ao Pentest na Prática | [Desec Security](https://desecsecurity.com/curso/introducao-pentest) | 🇧🇷 | 🆓 🎓 |
 | ⭐ Web Security Academy (o melhor do mundo, grátis) | [PortSwigger](https://portswigger.net/web-security) | 🇺🇸 | 🆓 🧪 |
 | ⭐ Jr Penetration Tester Path | [TryHackMe](https://tryhackme.com/path/outline/jrpenetrationtester) | 🇺🇸 | 🆓 parcial 🧪 🎓 |
 | Offensive Security Operations | [Cybrary](https://app.cybrary.it/browse/course/offensive-security-operations) | 🇺🇸 | 🆓 🎓 |
 | HTB Academy — módulos Tier 0 grátis | [HTB Academy](https://academy.hackthebox.com/) | 🇺🇸 | 🆓 parcial 🧪 |
 | Practical Ethical Hacking (aulas no YouTube) | [TCM Security](https://www.youtube.com/@TCMSecurityAcademy) | 🇺🇸 | 🆓 |
-| Getting Started in API Pen-Testing | [APIsec University](https://www.apisecuniversity.com/courses/) | 🇺🇸 | 🆓 🎓 |
-| API Penetration Testing | [APIsec University](https://www.apisecuniversity.com/courses/api-penetration-testing) | 🇺🇸 | 🆓 🎓 |
+| Getting Started in API Pen-Testing | [APIsec University](https://au.apisec.ai/courses/) | 🇺🇸 | 🆓 🎓 |
+| API Penetration Testing | [APIsec University](https://au.apisec.ai/courses/api-penetration-testing) | 🇺🇸 | 🆓 🎓 |
 | Android Application Security / Pentest | [Mobile Hacking Lab](https://www.mobilehackinglab.com/course/free-android-application-security-course) | 🇺🇸 | 🆓 🎓 |
 | iOS Application Security / Pentest | [Mobile Hacking Lab](https://www.mobilehackinglab.com/course/free-ios-application-security-course) | 🇺🇸 | 🆓 🎓 |
 | Android Frida Labs | [Mobile Hacking Lab](https://www.mobilehackinglab.com/course/android-frida-labs) | 🇺🇸 | 🆓 🎓 |
@@ -24,7 +24,7 @@
 | Antisyphon — cursos pay-what-you-can | [antisyphontraining.com](https://www.antisyphontraining.com/) | 🇺🇸 | 🆓/💳 |
 | OpenSecurityTraining2 | [ost2.fyi](https://ost2.fyi/) | 🇺🇸 | 🆓 🎓 |
 | Metasploit Unleashed | [OffSec](https://www.offsec.com/metasploit-unleashed/) | 🇺🇸 | 🆓 |
-| Kali Linux Revealed | [kali.training](https://kali.training/) | 🇺🇸 | 🆓 |
+| Kali Linux Revealed | [OffSec](https://www.offsec.com/kali-training/) | 🇺🇸 | 🆓 |
 | Bug Bounty — Hacker101 | [hacker101.com](https://www.hacker101.com/) | 🇺🇸 | 🆓 🧪 |
 | PentesterLab — exercícios grátis | [pentesterlab.com](https://pentesterlab.com/) | 🇺🇸 | 🆓 parcial 🧪 |
 

--- a/cursos/04-cloud-security.md
+++ b/cursos/04-cloud-security.md
@@ -11,11 +11,11 @@
 | AZ-900 Azure Fundamentals | [Microsoft Learn](https://learn.microsoft.com/training/) | 🇺🇸🇧🇷 | 🆓 |
 | ⭐ AWS Skill Builder (tier grátis + Builder Labs) | [skillbuilder.aws](https://skillbuilder.aws/) | 🇺🇸 | 🆓 🧪 🎓 |
 | AWS Cloud Practitioner Essentials | [AWS](https://skillbuilder.aws/) | 🇺🇸🇧🇷 | 🆓 |
-| Primeiros passos com AWS | [DIO](https://web.dio.me/course/primeiros-passos-com-aws/) | 🇧🇷 | 🆓 🎓 |
-| Introdução prática à computação em nuvem com AWS | [DIO](https://web.dio.me/course/Introducao-pratica-a-computacao-em-nuvem-usando-AWS/) | 🇧🇷 | 🆓 🎓 |
+| Conceitos básicos da Nuvem AWS | [AWS](https://aws.amazon.com/pt/getting-started/cloud-essentials/) | 🇧🇷 | 🆓 |
+| AWS Cloud Quest: Cloud Practitioner (labs guiados) | [AWS Skill Builder](https://skillbuilder.aws/cloudquest) | 🇺🇸🇧🇷 | 🆓 🧪 |
 | Cloud Fundamentals / Solution Architect | [FIAP / Eu Capacito](https://www.eucapacito.com.br/cursos/cloud-fundamentals/) | 🇧🇷 | 🆓 🎓 |
-| Google Cloud Skills Boost — badges grátis | [cloudskillsboost.google](https://www.cloudskillsboost.google/) | 🇺🇸 | 🆓 🧪 🎓 |
-| Fundamentals of Cloud Security | [Palo Alto Networks](https://www.paloaltonetworks.com/cyberpedia/free-cybersecurity-education-courses) | 🇺🇸 | 🆓 |
+| Google Skills — badges grátis | [skills.google](https://www.skills.google/) | 🇺🇸 | 🆓 🧪 🎓 |
+| Fundamentals of Cloud Security | [Palo Alto Beacon](https://learn.paloaltonetworks.com/) | 🇺🇸 | 🆓 |
 | ⭐ flaws.cloud (AWS attack lab) | [flaws.cloud](http://flaws.cloud/) | 🇺🇸 | 🆓 🧪 |
 | flaws2.cloud | [flaws2.cloud](http://flaws2.cloud/) | 🇺🇸 | 🆓 🧪 |
 | CloudGoat | [Rhino Security Labs](https://github.com/RhinoSecurityLabs/cloudgoat) | 🇺🇸 | 🆓 🧪 |

--- a/cursos/05-grc-compliance.md
+++ b/cursos/05-grc-compliance.md
@@ -19,8 +19,8 @@
 | ⭐ NIST Cybersecurity Framework 2.0 | [nist.gov](https://www.nist.gov/cyberframework) | 🇺🇸 | 🆓 |
 | NIST Risk Management Framework (RMF) courses | [csrc.nist.gov](https://csrc.nist.gov/projects/risk-management/rmf-courses) | 🇺🇸 | 🆓 |
 | CISA Free Training | [cisa.gov](https://www.cisa.gov/resources-tools/training) | 🇺🇸 | 🆓 🎓 |
-| FEMA IS Courses (certificados oficiais) | [training.fema.gov](https://training.fema.gov/is/) | 🇺🇸 | 🆓 🎓 |
-| API Security for PCI Compliance | [APIsec University](https://www.apisecuniversity.com/courses/api-security-for-pci-compliance) | 🇺🇸 | 🆓 🎓 |
+| FEMA IS Courses (certificados oficiais) | [training.fema.gov](https://training.fema.gov/programs/independent-study/) | 🇺🇸 | 🆓 🎓 |
+| API Security for PCI Compliance | [APIsec University](https://au.apisec.ai/courses/api-security-for-pci-compliance) | 🇺🇸 | 🆓 🎓 |
 | ISO/IEC 27001 — visão geral | [iso.org](https://www.iso.org/standard/27001) | 🇺🇸 | 🆓 |
 | Guias e cartilhas ANPD (LGPD oficial) | [gov.br/anpd](https://www.gov.br/anpd/pt-br) | 🇧🇷 | 🆓 |
 

--- a/cursos/06-appsec-devsecops.md
+++ b/cursos/06-appsec-devsecops.md
@@ -12,20 +12,20 @@
 | OWASP Cheat Sheet Series | [cheatsheetseries.owasp.org](https://cheatsheetseries.owasp.org/) | 🇺🇸 | 🆓 |
 | DevSecOps | [Cybrary](https://app.cybrary.it/browse/course/devsecops) | 🇺🇸 | 🆓 🎓 |
 | Fundamentals of Cybersecurity Architecture | [Cybrary](https://app.cybrary.it/browse/course/fundamentals-of-cybersecurity-architecture) | 🇺🇸 | 🆓 🎓 |
-| API Security Fundamentals | [APIsec University](https://www.apisecuniversity.com/courses/api-security-fundamentals) | 🇺🇸 | 🆓 🎓 |
-| OWASP API Security Top 10 and Beyond! | [APIsec University](https://www.apisecuniversity.com/courses/owasp-api-security-top-10-and-beyond) | 🇺🇸 | 🆓 🎓 |
-| Securing API Servers | [APIsec University](https://www.apisecuniversity.com/courses/securing-api-servers) | 🇺🇸 | 🆓 🎓 |
-| API Security in the World of DevSecOps | [APIsec University](https://www.apisecuniversity.com/courses/api-security-devsecops) | 🇺🇸 | 🆓 🎓 |
-| API Authentication Best Practices | [APIsec University](https://www.apisecuniversity.com/courses/api-authentication) | 🇺🇸 | 🆓 🎓 |
-| API Gateway Security Best Practices | [APIsec University](https://www.apisecuniversity.com/courses/api-gateway-best-practices) | 🇺🇸 | 🆓 🎓 |
-| API Documentation Best Practices | [APIsec University](https://www.apisecuniversity.com/courses/api-documentation-best-practices) | 🇺🇸 | 🆓 🎓 |
-| APIsec Power User | [APIsec University](https://www.apisecuniversity.com/courses/apisec-power-user) | 🇺🇸 | 🆓 🎓 |
-| Start Left: API SecDevOps | [APIsec University](https://www.apisecuniversity.com/courses/start-left-api-secdevops) | 🇺🇸 | 🆓 🎓 |
-| API Security for Connected Cars & Fleets | [APIsec University](https://www.apisecuniversity.com/courses/) | 🇺🇸 | 🆓 🎓 |
-| API Product Management Masterclass | [APIsec University](https://www.apisecuniversity.com/courses/api-product-management) | 🇺🇸 | 🆓 🎓 |
-| ⭐ MCP Security Fundamentals | [APIsec University](https://www.apisecuniversity.com/courses/mcp-security-fundamentals) | 🇺🇸 | 🆓 🎓 |
-| Building Security into AI | [APIsec University](https://www.apisecuniversity.com/courses/building-security-into-ai) | 🇺🇸 | 🆓 🎓 |
-| Securing LLM & NLP APIs | [APIsec University](https://www.apisecuniversity.com/courses/securing-llm-nlp-apis) | 🇺🇸 | 🆓 🎓 |
+| API Security Fundamentals | [APIsec University](https://au.apisec.ai/courses/api-security-fundamentals) | 🇺🇸 | 🆓 🎓 |
+| OWASP API Security Top 10 and Beyond! | [APIsec University](https://au.apisec.ai/courses/owasp-api-security-top-10) | 🇺🇸 | 🆓 🎓 |
+| Securing API Servers | [APIsec University](https://au.apisec.ai/courses/securing-api-servers) | 🇺🇸 | 🆓 🎓 |
+| API Security in the World of DevSecOps | [APIsec University](https://au.apisec.ai/courses/api-security-devsecops) | 🇺🇸 | 🆓 🎓 |
+| API Authentication Best Practices | [APIsec University](https://au.apisec.ai/courses/api-authentication) | 🇺🇸 | 🆓 🎓 |
+| API Gateway Security Best Practices | [APIsec University](https://au.apisec.ai/courses/api-gateway-best-practices) | 🇺🇸 | 🆓 🎓 |
+| API Documentation Best Practices | [APIsec University](https://au.apisec.ai/courses/api-documentation-best-practices) | 🇺🇸 | 🆓 🎓 |
+| APIsec Power User | [APIsec University](https://au.apisec.ai/courses/apisec-power-user) | 🇺🇸 | 🆓 🎓 |
+| Start Left: API SecDevOps | [APIsec University](https://au.apisec.ai/courses/start-left-api-secdevops) | 🇺🇸 | 🆓 🎓 |
+| API Security for Connected Cars & Fleets | [APIsec University](https://au.apisec.ai/courses/) | 🇺🇸 | 🆓 🎓 |
+| API Product Management Masterclass | [APIsec University](https://au.apisec.ai/courses/api-product-management) | 🇺🇸 | 🆓 🎓 |
+| ⭐ MCP Security Fundamentals | [APIsec University](https://au.apisec.ai/courses/mcp-security-fundamentals) | 🇺🇸 | 🆓 🎓 |
+| Building Security into AI | [APIsec University](https://au.apisec.ai/courses/building-security-into-ai) | 🇺🇸 | 🆓 🎓 |
+| Securing LLM & NLP APIs | [APIsec University](https://au.apisec.ai/courses/securing-llm-nlp-apis) | 🇺🇸 | 🆓 🎓 |
 | OWASP Top 10 for LLM Applications | [owasp.org](https://owasp.org/www-project-top-10-for-large-language-model-applications/) | 🇺🇸 | 🆓 |
 | Secure Code Warrior — free tier | [securecodewarrior.com](https://www.securecodewarrior.com/) | 🇺🇸 | 🆓 parcial 🧪 |
 | Snyk Learn | [learn.snyk.io](https://learn.snyk.io/) | 🇺🇸 | 🆓 🧪 |

--- a/cursos/07-malware-re-intel.md
+++ b/cursos/07-malware-re-intel.md
@@ -13,9 +13,9 @@
 | ⭐ AMO — Análise de Malware Online | [Mente Binária](https://www.mentebinaria.com.br/cursos/) | 🇧🇷 | 🆓 |
 | Malware Unicorn — RE workshops | [malwareunicorn.org](https://malwareunicorn.org/#/workshops) | 🇺🇸 | 🆓 🧪 |
 | Ghidra — curso oficial NSA | [ghidra-sre.org](https://ghidra-sre.org/) | 🇺🇸 | 🆓 |
-| Practical Malware Analysis labs | [practicalmalwareanalysis.com](https://practicalmalwareanalysis.com/labs/) | 🇺🇸 | 🆓 🧪 |
-| MITRE ATT&CK Defender (MAD) | [mitre.org](https://mitre-engenuity.org/cybersecurity/mad/) | 🇺🇸 | 🆓 parcial 🎓 |
-| Threat Intelligence — free courses | [Recorded Future University](https://www.recordedfuture.com/university) | 🇺🇸 | 🆓 🎓 |
+| Practical Malware Analysis labs | [GitHub (mirror dos binários)](https://github.com/mikesiko/PracticalMalwareAnalysis-Labs) | 🇺🇸 | 🆓 🧪 |
+| MITRE ATT&CK Defender (MAD20) | [mad20.com](https://mad20.com/) | 🇺🇸 | 💸 🎓 |
+| Threat Intelligence — free courses | [Recorded Future University](https://university.recordedfuture.com/) | 🇺🇸 | 🆓 🎓 |
 | OSINT — free training | [OSINT Framework](https://osintframework.com/) + [Bellingcat](https://www.bellingcat.com/category/resources/) | 🇺🇸 | 🆓 |
 | Any.Run / Hybrid Analysis (sandbox público) | [any.run](https://any.run/) | 🇺🇸 | 🆓 🧪 |
 

--- a/docs/trilha-pt-br.md
+++ b/docs/trilha-pt-br.md
@@ -13,7 +13,7 @@ Se você prefere estudar em português, esta é a sequência usando **apenas** m
 | 1 | [Primeiros Passos em Tecnologia](https://www.ev.org.br/trilhas-de-conhecimento/primeiros-passos-em-tecnologia) | Fundação Bradesco |
 | 2 | [Fundamentos de TI: Hardware e Software](https://www.ev.org.br/cursos/fundamentos-de-ti-hardware-e-software) | Fundação Bradesco |
 | 3 | [Conceitos Básicos de Redes](https://www.netacad.com/pt/courses/networking-basics) | Cisco NetAcad |
-| 4 | [Linux Fundamentos](https://www.eucapacito.com.br/curso-ec/linux-fundamentos/) | FIAP / Eu Capacito |
+| 4 | [Linux Fundamentos](https://www.eucapacito.com.br/cursos/linux-fundamentos/) | FIAP / Eu Capacito |
 | 5 | [CC50 — CS50 em português](https://materiais.napratica.org.br/cc50) | Fundação Estudar |
 
 ## Fase 2 — Segurança base 🇧🇷
@@ -29,9 +29,9 @@ Se você prefere estudar em português, esta é a sequência usando **apenas** m
 ## Fase 3 — Escolha a trilha 🇧🇷
 
 **🔴 Ofensiva**
-- [Introdução ao Hacking e Pentest 2.0](https://solyd.com.br/treinamentos/introducao-ao-hacking-e-pentest-2/) — Solyd
+- [Introdução ao Hacking e Pentest 2.0](https://solyd.com.br/cursos/introducao-ao-hacking-e-pentest-2/) — Solyd
 - [Introdução ao Pentest na Prática](https://desecsecurity.com/curso/introducao-pentest) — Desec Security
-- [Python Básico](https://solyd.com.br/treinamentos/python-basico/) — Solyd
+- [Python Básico](https://solyd.com.br/cursos/python-basico/) — Solyd
 
 **🔵 Defensiva / Baixo nível**
 - [CERO — Curso de Engenharia Reversa Online](https://www.mentebinaria.com.br/cursos/curso-de-engenharia-reversa-online-cero-r6/) — Mente Binária
@@ -45,7 +45,7 @@ Se você prefere estudar em português, esta é a sequência usando **apenas** m
 - [Intro ao CIS Controls](https://www.escolavirtual.gov.br/curso/1153) + [Controles 1-6](https://www.escolavirtual.gov.br/curso/1073) + [7-12](https://www.escolavirtual.gov.br/curso/1132) + [13-18](https://www.escolavirtual.gov.br/curso/1154)
 
 **☁️ Cloud**
-- [Primeiros passos com AWS](https://web.dio.me/course/primeiros-passos-com-aws/) — DIO
+- [Conceitos básicos da Nuvem AWS](https://aws.amazon.com/pt/getting-started/cloud-essentials/) — AWS
 - [Cloud Fundamentals](https://www.eucapacito.com.br/cursos/cloud-fundamentals/) — FIAP
 
 ## Leitura 🇧🇷

--- a/labs/home-lab.md
+++ b/labs/home-lab.md
@@ -64,7 +64,6 @@ Se estiver desativada, ligue na BIOS/UEFI: `Intel VT-x` / `AMD-V` ou `SVM Mode`.
 | Ubuntu Server | Grátis | [ubuntu.com](https://ubuntu.com/download/server) |
 | Windows Server — avaliação 180 dias | Grátis | [Microsoft Evaluation Center](https://www.microsoft.com/evalcenter) |
 | Windows 10/11 Enterprise — avaliação 90 dias | Grátis | [Microsoft Evaluation Center](https://www.microsoft.com/evalcenter) |
-| Windows dev VM (pronta, expira) | Grátis | [Windows dev environment](https://developer.microsoft.com/windows/downloads/virtual-machines/) |
 | Security Onion | Grátis | [securityonion.net](https://securityonionsolutions.com/) |
 | pfSense CE / OPNsense | Grátis | [opnsense.org](https://opnsense.org/) |
 

--- a/livros/gratuitos-pt.md
+++ b/livros/gratuitos-pt.md
@@ -9,7 +9,7 @@
 | ⭐ Fundamentos de Engenharia Reversa | Mente Binária | [gitbook](https://mentebinaria.gitbook.io/engenharia-reversa) | Engenharia reversa |
 | ⭐ Cartilha de Segurança para Internet | CERT.br | [cartilha.cert.br](https://cartilha.cert.br/) | Fundamentos, ótima para começar |
 | Livros e materiais Mente Binária | Mente Binária | [mentebinaria.com.br](https://www.mentebinaria.com.br/) | RE, malware, C |
-| Guias e Estudos Técnicos ANPD | ANPD (Governo) | [gov.br/anpd](https://www.gov.br/anpd/pt-br/assuntos/documentos-de-publicacoes) | LGPD |
+| Guias e Estudos Técnicos ANPD | ANPD (Governo) | [gov.br/anpd](https://www.gov.br/anpd/pt-br/centrais-de-conteudo) | LGPD |
 | Guia de Boas Práticas de Segurança (GSI/PR) | Gov. Federal | [gov.br/gsi](https://www.gov.br/gsi/pt-br) | GRC público |
 | Materiais de estudo — Engenharia Reversa | Mente Binária | [link](https://www.mentebinaria.com.br/studying-materials/registros/engenharia-reversa/) | RE |
 | RE4B — versão traduzida | Dennis Yurichev | [beginners.re](https://beginners.re/) | Assembly (versões multi-idioma) |

--- a/recursos/podcasts-comunidades.md
+++ b/recursos/podcasts-comunidades.md
@@ -13,7 +13,7 @@
 | [tl;dr sec](https://tldrsec.com/) | 🇺🇸 | Newsletter AppSec |
 | [Simply Cyber](https://simplycyber.io/) | 🇺🇸 | Brief diário |
 | [OWASP Brasil](https://owasp.org/chapters/) | 🇧🇷 | Capítulos locais e eventos |
-| [BSides Brasil / BHack / Roadsec](https://roadsec.com.br/) | 🇧🇷 | Conferências nacionais |
+| [BSides Brasil / BHack / Roadsec](https://www.roadsec.com.br/) | 🇧🇷 | Conferências nacionais |
 | [Coneds — OWASP Community Series](https://members.coneds.com.br/) | 🇧🇷 | Palestras gravadas |
 | [r/netsec](https://reddit.com/r/netsec) e [r/cybersecurity](https://reddit.com/r/cybersecurity) | 🇺🇸 | Comunidade |
 

--- a/recursos/youtube.md
+++ b/recursos/youtube.md
@@ -6,9 +6,9 @@
 
 | Canal | Foco |
 |---|---|
-| [Mente Binária / Papo Binário](https://www.youtube.com/@PapoBinario) | Engenharia reversa, malware, C, baixo nível |
+| [Mente Binária / Papo Binário](https://www.youtube.com/@mentebinaria) | Engenharia reversa, malware, C, baixo nível |
 | [Curso em Vídeo](https://www.youtube.com/@CursoemVideo) | Programação e fundamentos |
-| [Solyd Offensive Security](https://www.youtube.com/@SolydOfficial) | Pentest e hacking |
+| [Solyd Offensive Security](https://www.youtube.com/@solyd) | Pentest e hacking |
 | [Desec Security](https://www.youtube.com/@DesecSecurity) | Pentest prático |
 | [Gabriel Pato](https://www.youtube.com/@gabrielpato) | Carreira e segurança ofensiva |
 | [Código Fonte TV](https://www.youtube.com/@codigofontetv) | Tecnologia geral, contexto |


### PR DESCRIPTION
Os 275 links externos do repositório foram testados um a um. Este commit
mexe em 52 pontos: 51 URLs substituídas e 1 linha de tabela removida.

404 confirmados — 16 links em 7 grupos:
- TCM Security (3): academy.tcm-sec.com/p/* foi desativado. Mudou o padrão
  do caminho E o slug: /p/linux-fundamentals virou
  /academy/linux-100-fundamentals/.
- Practical Malware Analysis (1): practicalmalwareanalysis.com/labs/ morreu.
  Aponta para o mirror dos binários no GitHub — é mirror da comunidade,
  não repo oficial dos autores, e o texto do link diz isso.
- Recorded Future (1): mudou para university.recordedfuture.com.
- Palo Alto (4): /cyberpedia/free-cybersecurity-education-courses foi
  removida. Ver ressalva sobre links de home abaixo.
- ANPD (1): /assuntos/documentos-de-publicacoes virou /centrais-de-conteudo.
- YouTube (2): @PapoBinario e @SolydOfficial não existem mais. Os canais
  são @mentebinaria e @solyd.
- DIO (4): ver ressalva sobre troca de recurso abaixo.

Soft-404 — respondiam 200 escondendo página removida:
- elastic.co/training/free redirecionava para /getting-started. Aponta para
  /training, que ainda tem a seção de treinamento gratuito.
- Microsoft retirou as imagens de VM prontas em out/2024 e nunca voltou;
  linha removida (as duas linhas de ISO de avaliação logo acima cobrem o caso).
- MITRE ATT&CK Defender saiu da MITRE Engenuity para a MAD20 em set/2023 e
  virou assinatura paga. Ver ressalva sobre taxonomia abaixo.

Domínios migrados — 25 links:
- APIsec University -> au.apisec.ai (17; o slug do OWASP Top 10 encurtou)
- Google Cloud Skills Boost -> Google Skills / skills.google (2)
- Security Blue Team -> Centri / centri.org (1)
- Solyd: /treinamentos/ -> /cursos/ (2)
- FEMA: /is/ -> /programs/independent-study/ (2)
- INL ICS: raiz -> /learn (1)
- Linux Journey -> labex.io/linuxjourney (2)
- kali.training -> offsec.com/kali-training/ (1)

Outros:
- roadsec.com.br não resolvia DNS: o apex é CNAME para o Squarespace sem
  registro A. Trocado por www.
- Eu Capacito: o caminho /curso-ec/linux-fundamentos/ estava errado; o
  correto é /cursos/linux-fundamentos/. Descoberto por busca indexada, não
  por teste automatizado — o WAF do host devolve 403 para qualquer caminho,
  então curl não distingue caminho válido de inválido ali.

Três ressalvas honestas sobre o escopo deste commit:

1. Troca de recurso, não correção de link. A DIO removeu os cursos
   gratuitos e migrou para assinatura paga: não existe URL para corrigir.
   Os 4 links foram substituídos por equivalentes gratuitos em português
   verificados (AWS Cloud Essentials, AWS Cloud Quest e Curso em Vídeo
   HTML5/CSS3). São cursos diferentes, com outro título e outro provedor.

2. Adição de vocabulário. O símbolo 💸 (pago) não existia no repositório e
   foi introduzido junto da legenda no README, porque o MAD20 deixou de ser
   gratuito e as tabelas só tinham 🆓.

3. Links de home em vez de página do curso. Palo Alto, MAD20 e Recorded
   Future apontam para a raiz do portal. Não é desleixo: as páginas por
   curso do Palo Alto foram removidas e o catálogo é uma SPA atrás de
   login, o mesmo valendo para o Recorded Future University. A home é o
   melhor alvo público que existe hoje.

Os 403/429 restantes (TryHackMe, Eu Capacito, Mente Binária, ISO) são WAF
bloqueando automação: devolvem o mesmo código para caminhos inexistentes.
Foram verificados manualmente e estão vivos.
