### PR TITLE
fix: corrige informação errada e contraditória no conteúdo

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@ Every phase has an **hour budget**. Convert to calendar time with your own pace:
 Two parallel columns run through the whole thing:
 
 - 🟢 **FREE LANE** — costs nothing, ever. Everyone does this lane.
-- 💳 **PAID LANE** — optional exam vouchers. Never pay for *learning*; pay only for the *exam* that proves it. Tips in [Paid Lane](#-paid-lane--when-to-actually-spend-money).
+- 💳 **PAID LANE** — optional exam vouchers. Never pay for *learning*; pay only for the *exam* that proves it. Guia completo em [`docs/certificacoes.md`](./docs/certificacoes.md).
 
 **Rule of thumb:** don't buy an exam until you can already pass a free practice test at 85%.
 
@@ -56,7 +56,7 @@ Everything below is shared by all four tracks. Do not fork yet.
 
 **Exit test:** you can score >80% on free Security+ practice questions and write a Python script that parses a log file.
 
-💳 *First sensible paid moment is here — see [When to buy Security+](#-paid-lane--when-to-actually-spend-money).*
+💳 *First sensible paid moment is here — see [`docs/certificacoes.md`](./docs/certificacoes.md).*
 
 ---
 

--- a/cursos/00-fundamentos.md
+++ b/cursos/00-fundamentos.md
@@ -47,7 +47,7 @@
 | Crie um site com HTML, CSS e JavaScript | [Fundação Bradesco](https://www.ev.org.br/cursos/crie-um-site-simples-usando-html-css-e-javascript) | 🇧🇷 | 🆓 🎓 |
 | Curso de HTML5 e CSS3 (módulo 1) | [Curso em Vídeo](https://www.cursoemvideo.com/curso/html5-css3-modulo1/) | 🇧🇷 | 🆓 🎓 |
 | Java Development / Python Development / Android | [FIAP / Eu Capacito](https://www.eucapacito.com.br/cursos/) | 🇧🇷 | 🆓 🎓 |
-| ⭐ Curso de Programação em C | [Mente Binária](https://www.mentebinaria.com.br/cursos/) | 🇧🇷 | 🆓 🎓 |
+| ⭐ Programação Moderna em C | [Mente Binária](https://www.mentebinaria.com.br/cursos/programa%C3%A7%C3%A3o-moderna-em-c/) | 🇧🇷 | 🆓 🎓 |
 
 ---
 

--- a/cursos/07-malware-re-intel.md
+++ b/cursos/07-malware-re-intel.md
@@ -10,7 +10,7 @@
 | Foundations of Breach & Attack Simulation | [AttackIQ Academy](https://www.academy.attackiq.com/courses/foundations-of-breach-attack-simulation) | 🇺🇸 | 🆓 🎓 |
 | Foundations of Operationalizing MITRE ATT&CK | [AttackIQ Academy](https://www.academy.attackiq.com/courses/foundations-of-operationalizing-mitre-attck-v13) | 🇺🇸 | 🆓 🎓 |
 | ⭐ CERO — Curso de Engenharia Reversa Online | [Mente Binária](https://www.mentebinaria.com.br/cursos/curso-de-engenharia-reversa-online-cero-r6/) | 🇧🇷 | 🆓 |
-| ⭐ AMO — Análise de Malware Online | [Mente Binária](https://www.mentebinaria.com.br/cursos/) | 🇧🇷 | 🆓 |
+| ⭐ AMO — Análise de Malware Online | [Mente Binária](https://www.mentebinaria.com.br/cursos/an%C3%A1lise-de-malware-online-amo-r11/) | 🇧🇷 | 🆓 |
 | Malware Unicorn — RE workshops | [malwareunicorn.org](https://malwareunicorn.org/#/workshops) | 🇺🇸 | 🆓 🧪 |
 | Ghidra — curso oficial NSA | [ghidra-sre.org](https://ghidra-sre.org/) | 🇺🇸 | 🆓 |
 | Practical Malware Analysis labs | [GitHub (mirror dos binários)](https://github.com/mikesiko/PracticalMalwareAnalysis-Labs) | 🇺🇸 | 🆓 🧪 |

--- a/docs/como-documentar.md
+++ b/docs/como-documentar.md
@@ -17,59 +17,17 @@ github.com/seu-usuario/
 
 O repo `cybersecurity-portfolio` é só um README que aponta para os outros, com **uma frase por projeto explicando o que ele prova**. É a primeira coisa que o recrutador abre.
 
-## Template de README de projeto
+## Os templates
 
-```markdown
-# [Nome do Projeto]
+Não recrie do zero — copie o arquivo pronto:
 
-**O que este projeto prova:** [uma frase — a skill demonstrada]
+| Template | Quando usar | O que ele força você a preencher |
+|---|---|---|
+| [`README-projeto.md`](../projetos/templates/README-projeto.md) | Todo projeto que você publicar | Problema, ambiente, metodologia, resultados, **remediação**, o que quebrou, o que aprendeu |
+| [`writeup-ctf.md`](../projetos/templates/writeup-ctf.md) | Cada máquina / CTF resolvido | Resumo executivo, recon, exploração, **correção**, lições |
+| [`relatorio-pentest.md`](../projetos/templates/relatorio-pentest.md) | Quando quiser o formato de consultoria | Sumário executivo, escopo e regras de engajamento, achados com severidade, apêndices |
 
-## Problema
-Que situação real isso resolve ou simula.
-
-## Ambiente
-- SO / versões / ferramentas
-- Diagrama de rede (imagem)
-
-## Metodologia
-Passo a passo do que foi feito e **por quê** cada escolha.
-
-## Resultados
-Achados, alertas gerados, evidências. Screenshots com dados anonimizados.
-
-## Remediação / Recomendações
-O que você faria para corrigir. **Esta seção é a que mais impressiona.**
-
-## Problemas encontrados
-O que quebrou e como você resolveu. Mostra raciocínio real, não roteiro.
-
-## O que eu aprendi
-Honesto e específico. Inclusive o que você faria diferente.
-
-## Referências
-```
-
-## Template de writeup de CTF/lab
-
-```markdown
-# [Máquina/Desafio] — Writeup
-
-**Dificuldade:** | **Plataforma:** | **Data:**
-
-## Resumo executivo
-3 linhas: qual foi a falha, qual o impacto, como corrigir.
-
-## Reconhecimento
-Comandos + saída relevante (recortada, não colada inteira).
-
-## Exploração
-O raciocínio antes do comando. Por que você tentou isso?
-
-## Pós-exploração / escalada
-## Correção
-Como o administrador teria evitado. **Não pule esta parte.**
-## Lições
-```
+As duas seções que quase todo mundo pula — e que são exatamente as que impressionam — são **remediação** ("o que eu faria para corrigir") e **problemas encontrados** ("o que quebrou e como resolvi"). A primeira mostra que você pensa como defensor; a segunda mostra raciocínio real em vez de roteiro decorado.
 
 ## Checklist antes de publicar
 

--- a/docs/metodo-de-estudo.md
+++ b/docs/metodo-de-estudo.md
@@ -77,8 +77,8 @@ Independente de quantas horas você tem:
 
 | Fatia | % do tempo | O que é |
 |---|---|---|
-| Conteúdo novo | 50% | Curso, vídeo, livro |
-| Mão na massa | 30% | Lab, CTF, home lab |
+| Conteúdo novo | 30% | Curso, vídeo, livro |
+| Mão na massa | 50% | Lab, CTF, home lab |
 | Documentação | 15% | Notas, writeup, Anki |
 | Comunidade/notícias | 5% | Newsletter, Discord, LinkedIn |
 

--- a/docs/trilha-pt-br.md
+++ b/docs/trilha-pt-br.md
@@ -35,8 +35,8 @@ Se você prefere estudar em português, esta é a sequência usando **apenas** m
 
 **🔵 Defensiva / Baixo nível**
 - [CERO — Curso de Engenharia Reversa Online](https://www.mentebinaria.com.br/cursos/curso-de-engenharia-reversa-online-cero-r6/) — Mente Binária
-- [AMO — Análise de Malware Online](https://www.mentebinaria.com.br/cursos/) — Mente Binária
-- [Curso de Programação em C](https://www.mentebinaria.com.br/cursos/) — Mente Binária
+- [AMO — Análise de Malware Online](https://www.mentebinaria.com.br/cursos/an%C3%A1lise-de-malware-online-amo-r11/) — Mente Binária
+- [Programação Moderna em C](https://www.mentebinaria.com.br/cursos/programa%C3%A7%C3%A3o-moderna-em-c/) — Mente Binária
 
 **📋 GRC / LGPD** — a área com mais material gratuito em português
 - [Fundamentos da LGPD](https://www.escolavirtual.gov.br/curso/603)

--- a/labs/blue-team.md
+++ b/labs/blue-team.md
@@ -12,7 +12,7 @@
 | [Splunk BOTS](https://bots.splunk.com/) | 🇺🇸 | 🆓 🧪 | Boss of the SOC datasets |
 | [DetectionLab](https://github.com/clong/DetectionLab) | 🇺🇸 | 🆓 🧪 | Lab de detecção automatizado |
 | [Malware-Traffic-Analysis.net](https://www.malware-traffic-analysis.net/) | 🇺🇸 | 🆓 🧪 | PCAPs reais para treinar |
-| [RangeForce Community](https://www.rangeforce.com/) | 🇺🇸 | 🆓 tier 🧪 | |
+| [RangeForce Community](https://www.rangeforce.com/) | 🇺🇸 | 🆓 tier 🧪 | Módulos hands-on de blue team no navegador |
 | [Sigma HQ](https://github.com/SigmaHQ/sigma) | 🇺🇸 | 🆓 | Regras de detecção — contribua! |
 
 ---

--- a/labs/red-team-ctf.md
+++ b/labs/red-team-ctf.md
@@ -17,7 +17,7 @@
 | [Metasploitable](https://sourceforge.net/projects/metasploitable/) | 🇺🇸 | 🆓 🧪 | VM alvo clássica |
 | [TryHackMe](https://tryhackme.com/) | 🇺🇸 | 🆓 parcial 🧪 | Salas grátis diárias |
 | [HackerOne CTF](https://ctf.hacker101.com/) | 🇺🇸 | 🆓 🧪 | Leva a convites de bug bounty |
-| [Bugcrowd University](https://www.bugcrowd.com/hackers/bugcrowd-university/) | 🇺🇸 | 🆓 | |
+| [Bugcrowd University](https://www.bugcrowd.com/hackers/bugcrowd-university/) | 🇺🇸 | 🆓 | Currículo de bug bounty, do recon ao report |
 
 ---
 

--- a/livros/gratuitos-pt.md
+++ b/livros/gratuitos-pt.md
@@ -11,7 +11,7 @@
 | Livros e materiais Mente Binária | Mente Binária | [mentebinaria.com.br](https://www.mentebinaria.com.br/) | RE, malware, C |
 | Guias e Estudos Técnicos ANPD | ANPD (Governo) | [gov.br/anpd](https://www.gov.br/anpd/pt-br/centrais-de-conteudo) | LGPD |
 | Guia de Boas Práticas de Segurança (GSI/PR) | Gov. Federal | [gov.br/gsi](https://www.gov.br/gsi/pt-br) | GRC público |
-| Materiais de estudo — Engenharia Reversa | Mente Binária | [link](https://www.mentebinaria.com.br/studying-materials/registros/engenharia-reversa/) | RE |
+| Materiais de estudo — Engenharia Reversa | Mente Binária | [mentebinaria.com.br](https://www.mentebinaria.com.br/studying-materials/registros/engenharia-reversa/) | RE |
 | RE4B — versão traduzida | Dennis Yurichev | [beginners.re](https://beginners.re/) | Assembly (versões multi-idioma) |
 
 ---

--- a/projetos/05-grc.md
+++ b/projetos/05-grc.md
@@ -22,7 +22,7 @@
 **Prova que:** domina o contexto brasileiro — vantagem local enorme.
 **Tempo:** 20–30h
 **Entregável:** mapeamento de dados (data mapping), RIPD (Relatório de Impacto), base legal por tratamento, fluxo de atendimento ao titular, e plano de resposta a incidente de dados com prazo ANPD.
-**Fonte:** [Guias oficiais ANPD](https://www.gov.br/anpd/pt-br)
+**Fonte:** [Guias e estudos técnicos da ANPD](https://www.gov.br/anpd/pt-br/centrais-de-conteudo)
 
 ### P29 — Programa de gestão de fornecedores
 **Tempo:** 10–15h

--- a/recursos/youtube.md
+++ b/recursos/youtube.md
@@ -6,7 +6,7 @@
 
 | Canal | Foco |
 |---|---|
-| [Mente Binária / Papo Binário](https://www.youtube.com/@mentebinaria) | Engenharia reversa, malware, C, baixo nível |
+| [Mente Binária](https://www.youtube.com/@mentebinaria) | Engenharia reversa, malware, C, baixo nível |
 | [Curso em Vídeo](https://www.youtube.com/@CursoemVideo) | Programação e fundamentos |
 | [Solyd Offensive Security](https://www.youtube.com/@solyd) | Pentest e hacking |
 | [Desec Security](https://www.youtube.com/@DesecSecurity) | Pentest prático |
@@ -20,10 +20,9 @@
 | [Professor Messer](https://www.youtube.com/@professormesser) | Security+ / Network+ completo |
 | [John Hammond](https://www.youtube.com/@_JohnHammond) | CTF, malware, ofensivo |
 | [IppSec](https://www.youtube.com/@ippsec) | Walkthroughs HTB — ouro puro |
-| [TCM Security](https://www.youtube.com/@TCMSecurityAcademy) | Cursos completos grátis |
+| [TCM Security / The Cyber Mentor](https://www.youtube.com/@TCMSecurityAcademy) | Cursos completos grátis, pentest prático |
 | [LiveOverflow](https://www.youtube.com/@LiveOverflow) | Binary exploitation, pesquisa |
 | [NetworkChuck](https://www.youtube.com/@NetworkChuck) | Redes e entrada na área |
-| [The Cyber Mentor](https://www.youtube.com/@TCMSecurityAcademy) | Pentest prático |
 | [13Cubed](https://www.youtube.com/@13Cubed) | DFIR e forense Windows |
 | [SANS Offensive Operations](https://www.youtube.com/@SANSOffensiveOperations) | Webcasts avançados |
 | [Black Hat](https://www.youtube.com/@BlackHatOfficialYT) | Palestras de conferência |


### PR DESCRIPTION
Achados de uma leitura completa dos 48 arquivos. Nenhum destes seria
pego por um verificador de links.

1. O repositório se contradizia sobre a divisão do tempo de estudo.
   docs/metodo-de-estudo.md tinha duas tabelas incompatíveis: "3 camadas"
   prescrevia 30% aprender / 50% fazer / 20% documentar, e "Ritmo semanal"
   prescrevia 50% conteúdo / 30% prática. O README, o labs/README.md e o
   princípio "Fazer > assistir" todos apoiam 50% de prática — a tabela do
   ritmo semanal era a única discordante. Invertida.

2. Templates duplicados e já divergentes. docs/como-documentar.md embutia
   cópias dos templates de README-de-projeto e writeup-de-CTF que já existem
   como arquivo em projetos/templates/ — e as versões em arquivo são
   superconjuntos (têm tabela de severidade, badges, seções extras). As
   cópias inline eram versões velhas. Substituídas por uma tabela que linka
   os três arquivos, mantendo o que era único ali.

3. recursos/youtube.md listava o mesmo canal duas vezes. "TCM Security" e
   "The Cyber Mentor" apontavam ambos para @TCMSecurityAcademy, cujo nome
   é literalmente "The Cyber Mentors" (@TheCyberMentor devolve 404).
   Linhas fundidas. Também removida a menção a "Papo Binário", que não
   existe mais como canal separado.

4. Duas âncoras internas quebradas no ROADMAP.md. A seção "Paid Lane" foi
   apagada em algum momento, mas dois links continuaram apontando para ela.
   Redirecionados para docs/certificacoes.md, onde a informação está.

5. Duas células vazias em tabela (RangeForce, Bugcrowd University) —
   preenchidas com a nota que a coluna pede.

6. Um link com texto genérico "[link]" em livros/gratuitos-pt.md, ruim para
   escanear e para leitor de tela.

7. Links que apontavam para índice genérico em vez da página do curso,
   obrigando a pessoa a caçar: AMO e Programação Moderna em C (ambos
   iam para mentebinaria.com.br/cursos/) e a fonte da ANPD no projeto P28.
