### PR TITLE
docs: traduz ROADMAP e certificações para PT-BR

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,133 +5,130 @@
 
 ---
 
-## How to read this
+## Como ler este roadmap
 
-Every phase has an **hour budget**. Convert to calendar time with your own pace:
+Cada fase tem um **orçamento de horas**. Converta em tempo de calendário usando o seu próprio ritmo:
 
-| Your pace | Phase 0+1 (~180h) | Through Phase 3 (~450h) | Full roadmap (~650h) |
+| Seu ritmo | Fases 0+1 (~180h) | Até a Fase 3 (~450h) | Roadmap completo (~650h) |
 |---|---|---|---|
-| 5 h/week | ~9 months | ~21 months | ~30 months |
-| 10 h/week | ~4.5 months | ~11 months | ~15 months |
-| 20 h/week | ~2 months | ~5.5 months | ~8 months |
+| 5 h/semana | ~9 meses | ~21 meses | ~30 meses |
+| 10 h/semana | ~4,5 meses | ~11 meses | ~15 meses |
+| 20 h/semana | ~2 meses | ~5,5 meses | ~8 meses |
 
-Two parallel columns run through the whole thing:
+Duas faixas paralelas atravessam o roadmap inteiro:
 
-- 🟢 **FREE LANE** — costs nothing, ever. Everyone does this lane.
-- 💳 **PAID LANE** — optional exam vouchers. Never pay for *learning*; pay only for the *exam* that proves it. Guia completo em [`docs/certificacoes.md`](./docs/certificacoes.md).
+- 🟢 **FAIXA GRATUITA** — nunca custa nada. Todo mundo faz esta faixa.
+- 💳 **FAIXA PAGA** — vouchers de exame, opcionais. Nunca pague pelo *aprendizado*; pague só pelo *exame* que o comprova. Guia completo em [`docs/certificacoes.md`](./docs/certificacoes.md).
 
-**Rule of thumb:** don't buy an exam until you can already pass a free practice test at 85%.
+**Regra de bolso:** não compre um exame antes de já acertar 85% num simulado gratuito.
 
 ---
 
-## Phase 0 — Foundations (~70h)
+## Fase 0 — Fundamentos (~70h)
 
-You cannot secure what you don't understand. Skip this only if you already admin Linux and can explain a TCP handshake.
+Você não protege o que não entende. Pule esta fase só se você já administra Linux e sabe explicar um handshake TCP.
 
-| # | What | Where | Hours | Free cert? |
+| # | O que | Onde | Horas | Certificado grátis? |
 |---|---|---|---|---|
-| 0.1 | Networking basics (OSI, TCP/IP, DNS, DHCP, routing) | [Cisco Networking Basics](https://www.netacad.com/courses/networking-basics) | 20 | ✅ Badge |
-| 0.2 | Intro to Cybersecurity | [Cisco Intro to Cybersecurity](https://www.netacad.com/courses/introduction-to-cybersecurity) | 6 | ✅ Badge |
-| 0.3 | Linux command line | [TryHackMe Pre-Security path](https://tryhackme.com/path/outline/presecurity) (free rooms) + [Linux Journey](https://labex.io/linuxjourney) | 20 | ⚪ |
-| 0.4 | Windows internals + AD basics | [Microsoft Learn — Windows Server fundamentals](https://learn.microsoft.com/training/) | 12 | ⚪ |
-| 0.5 | Threat landscape awareness | [Fortinet NSE 1 + 2 + 3](https://training.fortinet.com/) | 6 | ✅ 3 badges |
-| 0.6 | Build a home lab | VirtualBox/Proxmox + Kali + Ubuntu + Windows eval VMs | 6 | ⚪ |
+| 0.1 | Redes básicas (OSI, TCP/IP, DNS, DHCP, roteamento) | [Cisco Networking Basics](https://www.netacad.com/courses/networking-basics) | 20 | ✅ Badge |
+| 0.2 | Introdução à cibersegurança | [Cisco Intro to Cybersecurity](https://www.netacad.com/courses/introduction-to-cybersecurity) | 6 | ✅ Badge |
+| 0.3 | Linha de comando Linux | [TryHackMe Pre-Security path](https://tryhackme.com/path/outline/presecurity) (salas gratuitas) + [Linux Journey](https://labex.io/linuxjourney) | 20 | ⚪ |
+| 0.4 | Internals do Windows + noções de AD | [Microsoft Learn — Windows Server fundamentals](https://learn.microsoft.com/training/) | 12 | ⚪ |
+| 0.5 | Panorama de ameaças | [Fortinet NSE 1 + 2 + 3](https://training.fortinet.com/) | 6 | ✅ 3 badges |
+| 0.6 | Montar um home lab | VirtualBox/Proxmox + Kali + Ubuntu + VMs de avaliação do Windows | 6 | ⚪ |
 
-**Exit test:** you can spin up a VM, read `ip a`, capture traffic in Wireshark, and explain what a firewall rule does.
-
----
-
-## Phase 1 — Security Core (~110h)
-
-Everything below is shared by all four tracks. Do not fork yet.
-
-| # | What | Where | Hours |
-|---|---|---|---|
-| 1.1 | Security fundamentals (CIA, AAA, controls, crypto basics) | [Professor Messer Security+ course](https://www.professormesser.com/) — 100% free video | 35 |
-| 1.2 | Cybersecurity analyst foundations | [IBM SkillsBuild — Cybersecurity Fundamentals](https://skillsbuild.org/) | 15 |
-| 1.3 | Google Cybersecurity Certificate (audit / financial aid) | [Coursera](https://www.coursera.org/professional-certificates/google-cybersecurity) — audit free, or apply Financial Aid for the cert | 25 |
-| 1.4 | Microsoft security/compliance/identity fundamentals | [SC-900 learning path on Microsoft Learn](https://learn.microsoft.com/training/) | 12 |
-| 1.5 | MITRE ATT&CK literacy | [MITRE ATT&CK official training](https://attack.mitre.org/resources/training/) | 10 |
-| 1.6 | Scripting: Python + Bash for security | [Automate the Boring Stuff](https://automatetheboringstuff.com/) | 13 |
-
-**Exit test:** you can score >80% on free Security+ practice questions and write a Python script that parses a log file.
-
-💳 *First sensible paid moment is here — see [`docs/certificacoes.md`](./docs/certificacoes.md).*
+**Teste de saída:** você consegue subir uma VM, ler `ip a`, capturar tráfego no Wireshark e explicar o que uma regra de firewall faz.
 
 ---
 
-## Phase 2 — The Fork: Hands-On per Track (~120h each)
+## Fase 1 — Núcleo de segurança (~110h)
 
-Pick **one** primary track now. You said all four interest you — that's fine, but do them **sequentially**, not in parallel. Order I'd recommend: **Blue Team → Cloud → Red Team → GRC** (blue team hires fastest, cloud pays most, red team is the most competitive entry, GRC rewards experience you don't have yet).
+Tudo aqui é comum às quatro trilhas. **Não se especialize ainda.**
 
-### 🔵 2A — Blue Team / SOC Analyst (~120h)
-
-| What | Where | Hours | Free? |
+| # | O que | Onde | Horas |
 |---|---|---|---|
-| SOC Level 1 path | [TryHackMe SOC Level 1](https://tryhackme.com/path/outline/soclevel1) | 45 | Partly free, ~$14/mo for full |
-| Splunk fundamentals + BOTS datasets | [Splunk Free Training](https://www.splunk.com/en_us/training/free-courses/overview.html) + [BOTS](https://bots.splunk.com/) | 20 | ✅ Free |
-| Alert triage in a real SOC UI | [LetsDefend free tier](https://letsdefend.io/) | 20 | ✅ Free tier |
-| DFIR / blue team challenges | [CyberDefenders](https://cyberdefenders.org/) — generous free labs | 20 | ✅ Free tier |
-| Investigation depth | [Blue Team Labs Online](https://blueteamlabs.online/) free challenges | 15 | ✅ Partly |
+| 1.1 | Fundamentos de segurança (CID, AAA, controles, noções de cripto) | [Professor Messer Security+](https://www.professormesser.com/) — vídeo 100% gratuito | 35 |
+| 1.2 | Base de analista de cibersegurança | [IBM SkillsBuild — Cybersecurity Fundamentals](https://skillsbuild.org/) | 15 |
+| 1.3 | Google Cybersecurity Certificate (audit / ajuda financeira) | [Coursera](https://www.coursera.org/professional-certificates/google-cybersecurity) — audit gratuito, ou peça Financial Aid para o certificado | 25 |
+| 1.4 | Fundamentos de segurança, compliance e identidade da Microsoft | [Trilha SC-900 no Microsoft Learn](https://learn.microsoft.com/training/) | 12 |
+| 1.5 | Fluência em MITRE ATT&CK | [Treinamento oficial MITRE ATT&CK](https://attack.mitre.org/resources/training/) | 10 |
+| 1.6 | Scripting: Python + Bash para segurança | [Automate the Boring Stuff](https://automatetheboringstuff.com/) | 13 |
+
+**Teste de saída:** você tira mais de 80% num simulado gratuito de Security+ e escreve um script Python que parseia um arquivo de log.
+
+💳 *Este é o primeiro momento em que faz sentido pagar por algo — veja [`docs/certificacoes.md`](./docs/certificacoes.md).*
+
+---
+
+## Fase 2 — A bifurcação: prática por trilha (~120h cada)
+
+Escolha **uma** trilha principal agora. Se todas te interessam, tudo bem — mas faça **em sequência**, não em paralelo. Ordem que eu recomendo: **Blue Team → Cloud → Red Team → GRC** (blue team contrata mais rápido, cloud paga melhor, red team é a entrada mais concorrida, e GRC premia experiência que você ainda não tem).
+
+### 🔵 2A — Blue Team / Analista de SOC (~120h)
+
+| O que | Onde | Horas | Gratuito? |
+|---|---|---|---|
+| Trilha SOC Level 1 | [TryHackMe SOC Level 1](https://tryhackme.com/path/outline/soclevel1) | 45 | Parcial; ~US$ 14/mês para tudo |
+| Splunk fundamentals + datasets BOTS | [Splunk Free Training](https://www.splunk.com/en_us/training/free-courses/overview.html) + [BOTS](https://bots.splunk.com/) | 20 | ✅ Grátis |
+| Triagem de alertas numa UI real de SOC | [LetsDefend — tier gratuito](https://letsdefend.io/) | 20 | ✅ Tier grátis |
+| Desafios de DFIR / blue team | [CyberDefenders](https://cyberdefenders.org/) — labs gratuitos generosos | 20 | ✅ Tier grátis |
+| Profundidade de investigação | [Blue Team Labs Online](https://blueteamlabs.online/) — desafios gratuitos | 15 | ✅ Parcial |
 
 ### 🔴 2B — Red Team / Pentest (~120h)
 
-| What | Where | Hours | Free? |
+| O que | Onde | Horas | Gratuito? |
 |---|---|---|---|
-| Web vulns — the gold standard | [PortSwigger Web Security Academy](https://portswigger.net/web-security) | 45 | ✅ 100% free |
-| Jr Penetration Tester path | [TryHackMe](https://tryhackme.com/path/outline/jrpenetrationtester) | 35 | Partly free |
-| Linux privesc wargames | [OverTheWire Bandit → Natas](https://overthewire.org/wargames/) | 15 | ✅ Free |
-| Practical ethical hacking | [TCM Security YouTube](https://www.youtube.com/@TCMSecurityAcademy) full courses | 15 | ✅ Free |
-| CTF muscle | [picoCTF](https://picoctf.org/) | 10 | ✅ Free |
+| Vulns web — o padrão-ouro | [PortSwigger Web Security Academy](https://portswigger.net/web-security) | 45 | ✅ 100% grátis |
+| Trilha Jr Penetration Tester | [TryHackMe](https://tryhackme.com/path/outline/jrpenetrationtester) | 35 | Parcial |
+| Wargames de privesc em Linux | [OverTheWire Bandit → Natas](https://overthewire.org/wargames/) | 15 | ✅ Grátis |
+| Hacking ético prático | [TCM Security no YouTube](https://www.youtube.com/@TCMSecurityAcademy) — cursos completos | 15 | ✅ Grátis |
+| Músculo de CTF | [picoCTF](https://picoctf.org/) | 10 | ✅ Grátis |
 
 ### ☁️ 2C — Cloud Security (~120h)
 
-| What | Where | Hours | Free? |
+| O que | Onde | Horas | Gratuito? |
 |---|---|---|---|
-| Azure security ops (SC-200 path) | [Microsoft Learn](https://learn.microsoft.com/training/) | 35 | ✅ Free |
-| AWS security fundamentals + labs | [AWS Skill Builder](https://skillbuilder.aws/) free tier + Builder Labs | 30 | ✅ Free tier |
-| GCP security badges | [Google Skills](https://www.skills.google/) free courses | 25 | ✅ Free tier |
-| Cloud attack/defense practice | [flaws.cloud](http://flaws.cloud/) + [flaws2.cloud](http://flaws2.cloud/) + [CloudGoat](https://github.com/RhinoSecurityLabs/cloudgoat) | 20 | ✅ Free |
-| IaC + container security | [Kubernetes Goat](https://madhuakula.com/kubernetes-goat/) | 10 | ✅ Free |
+| Operações de segurança no Azure (trilha SC-200) | [Microsoft Learn](https://learn.microsoft.com/training/) | 35 | ✅ Grátis |
+| Fundamentos de segurança AWS + labs | [AWS Skill Builder](https://skillbuilder.aws/) — tier gratuito + Builder Labs | 30 | ✅ Tier grátis |
+| Badges de segurança no GCP | [Google Skills](https://www.skills.google/) — cursos gratuitos | 25 | ✅ Tier grátis |
+| Prática de ataque/defesa em nuvem | [flaws.cloud](http://flaws.cloud/) + [flaws2.cloud](http://flaws2.cloud/) + [CloudGoat](https://github.com/RhinoSecurityLabs/cloudgoat) | 20 | ✅ Grátis |
+| Segurança de IaC e contêineres | [Kubernetes Goat](https://madhuakula.com/kubernetes-goat/) | 10 | ✅ Grátis |
 
 ### 📋 2D — GRC / Compliance (~90h)
 
-| What | Where | Hours | Free? |
+| O que | Onde | Horas | Gratuito? |
 |---|---|---|---|
-| NIST Cybersecurity Framework 2.0 | [NIST CSF official resources](https://www.nist.gov/cyberframework) | 20 | ✅ Free |
-| NIST RMF + SP 800-53 | [NIST RMF training](https://csrc.nist.gov/projects/risk-management/rmf-courses) | 20 | ✅ Free |
-| Federal/critical-infra courses | [CISA free training](https://www.cisa.gov/resources-tools/training) + [FEMA IS courses](https://training.fema.gov/programs/independent-study/) | 20 | ✅ Free + certs |
-| ISO 27001 structure | [ISO 27001 overview material](https://www.iso.org/standard/27001) + free vendor webinars | 15 | ✅ Free |
-| Risk & audit practice | Build a real risk register + control matrix for a fake company | 15 | ✅ Free |
+| NIST Cybersecurity Framework 2.0 | [Material oficial do NIST CSF](https://www.nist.gov/cyberframework) | 20 | ✅ Grátis |
+| NIST RMF + SP 800-53 | [Treinamento NIST RMF](https://csrc.nist.gov/projects/risk-management/rmf-courses) | 20 | ✅ Grátis |
+| Cursos federais / infra crítica | [CISA free training](https://www.cisa.gov/resources-tools/training) + [FEMA IS courses](https://training.fema.gov/programs/independent-study/) | 20 | ✅ Grátis + certificados |
+| Estrutura da ISO 27001 | [Visão geral da ISO 27001](https://www.iso.org/standard/27001) + webinars gratuitos de fornecedores | 15 | ✅ Grátis |
+| Prática de risco e auditoria | Monte um risk register e uma matriz de controles reais para uma empresa fictícia | 15 | ✅ Grátis |
 
 ---
 
-## Phase 3 — Depth & Proof (~150h)
+## Fase 3 — Profundidade e prova (~150h)
 
-Now you specialize *and* you make it visible. Split roughly 60/40 between learning and producing artifacts.
+Agora você se especializa *e* torna isso visível. Divida mais ou menos 60/40 entre aprender e produzir artefatos.
 
-| # | What | Hours |
+| # | O que | Horas |
 |---|---|---|
-| 3.1 | Advanced path in your chosen track (HTB Academy free modules, Antisyphon pay-what-you-can courses, OpenSecurityTraining2) | 60 |
-| 3.2 | **Home lab project** — build a detection lab (Security Onion / Wazuh / ELK), attack it, detect yourself | 40 |
-| 3.3 | **Write it up** — 6–10 blog posts or GitHub writeups documenting labs, CTFs, detections you built | 30 |
-| 3.4 | Second track from Phase 2 (breadth) | 20 |
+| 3.1 | Trilha avançada na sua área (módulos gratuitos da HTB Academy, cursos pay-what-you-can da Antisyphon, OpenSecurityTraining2) | 60 |
+| 3.2 | **Projeto de home lab** — monte um lab de detecção (Security Onion / Wazuh / ELK), ataque-o e detecte a si mesmo | 40 |
+| 3.3 | **Escreva** — 6 a 10 posts ou writeups no GitHub documentando labs, CTFs e detecções que você construiu | 30 |
+| 3.4 | Segunda trilha da Fase 2 (amplitude) | 20 |
 
-**This phase is what actually gets you hired.** Certificates get past HR; the lab writeups get you past the technical interview.
+**É esta fase que realmente te contrata.** Certificado passa pelo RH; os writeups de lab passam pela entrevista técnica.
 
 ---
 
-## Phase 4 — Job-Ready (~100h, ongoing)
+## Fase 4 — Pronto para o mercado (~100h, contínuo)
 
-| # | What | Hours |
+| # | O que | Horas |
 |---|---|---|
-| 4.1 | Resume + LinkedIn rebuilt around projects, not courses | 10 |
-| 4.2 | Interview prep — practice explaining your labs out loud | 20 |
-| 4.3 | Contribute: open-source detection rules (Sigma), CTF writeups, bug bounty on [HackerOne](https://hackerone.com/) free programs | 40 |
-| 4.4 | Continuous: [SANS free webcasts](https://www.sans.org/webcasts/), threat intel newsletters, Simply Cyber daily briefs | 30+ |
-
----
-
+| 4.1 | Currículo + LinkedIn reescritos em torno de projetos, não de cursos | 10 |
+| 4.2 | Preparo para entrevista — treine explicar seus labs em voz alta | 20 |
+| 4.3 | Contribua: regras de detecção open source (Sigma), writeups de CTF, bug bounty em programas gratuitos do [HackerOne](https://hackerone.com/) | 40 |
+| 4.4 | Contínuo: [webcasts gratuitos da SANS](https://www.sans.org/webcasts/), newsletters de threat intel, briefings diários do Simply Cyber | 30+ |
 
 ---
 
@@ -139,7 +136,7 @@ Now you specialize *and* you make it visible. Split roughly 60/40 between learni
 
 Se você quiser apenas **uma lista sequencial** sem pensar muito:
 
-1. Cisco *Introdução à Cibersegurança* 🇧🇷 → 2. Cisco *Conceitos Básicos de Redes* 🇧🇷 → 3. Fundação Bradesco *Segurança em TI* 🇧🇷 → 4. CC50/CS50 → 5. TCM *Linux 100* → 6. Fortinet FCF+FCA → 7. Professor Messer Security+ 🇺🇸 → 8. Google Cybersecurity Certificate → 9. **ESCOLHA A TRILHA** → 10a. Blue: THM SOC L1 + Splunk + LetsDefend + CyberDefenders · 10b. Red: PortSwigger + Solyd Intro + THM Jr Pentester + picoCTF · 10c. Cloud: SC-200 + AWS Skill Builder + flaws.cloud · 10d. GRC: LGPD EV.gov + CIS Controls + NIST CSF → 11. Home lab + writeups → 12. Certificação paga (ver roadmap).
+1. Cisco *Introdução à Cibersegurança* 🇧🇷 → 2. Cisco *Conceitos Básicos de Redes* 🇧🇷 → 3. Fundação Bradesco *Segurança em TI* 🇧🇷 → 4. CC50/CS50 → 5. TCM *Linux 100* → 6. Fortinet FCF+FCA → 7. Professor Messer Security+ 🇺🇸 → 8. Google Cybersecurity Certificate → 9. **ESCOLHA A TRILHA** → 10a. Blue: THM SOC L1 + Splunk + LetsDefend + CyberDefenders · 10b. Red: PortSwigger + Solyd Intro + THM Jr Pentester + picoCTF · 10c. Cloud: SC-200 + AWS Skill Builder + flaws.cloud · 10d. GRC: LGPD EV.gov + CIS Controls + NIST CSF → 11. Home lab + writeups → 12. Certificação paga (ver [`docs/certificacoes.md`](./docs/certificacoes.md)).
 
 > **Meta-conselho:** você não vai terminar tudo aqui — e nem deve. Este catálogo é um **menu**, não uma lista de tarefas. Escolha 1 curso por vez, termine, documente, e só então pegue o próximo.
 
@@ -150,3 +147,4 @@ Se você quiser apenas **uma lista sequencial** sem pensar muito:
 - Projetos para provar cada fase → [`projetos/`](./projetos/)
 - Como estudar de forma eficiente → [`docs/metodo-de-estudo.md`](./docs/metodo-de-estudo.md)
 - Acompanhar progresso → [`progresso/checklist.md`](./progresso/checklist.md)
+

--- a/docs/certificacoes.md
+++ b/docs/certificacoes.md
@@ -4,46 +4,49 @@
 
 ---
 
-These give you a real, verifiable credential or badge without paying anything:
+## 🆓 Faixa gratuita — credencial de verdade, sem pagar nada
 
-| Credential | Provider | Effort | Notes |
+Estas dão uma credencial ou badge real e verificável sem custo:
+
+| Credencial | Provedor | Esforço | Nota |
 |---|---|---|---|
-| Networking Basics badge | Cisco Networking Academy | 20h | Genuinely free, credible name |
-| Intro to Cybersecurity badge | Cisco Networking Academy | 6h | Best absolute-beginner win |
-| NSE 1 / 2 / 3 | Fortinet | 6h | Free self-paced, digital badges |
-| Cybersecurity Fundamentals | IBM SkillsBuild | 15h | Free badge, hands-on labs |
-| Microsoft Learn achievements | Microsoft | varies | Free learning; the *exam* is paid |
-| AWS / GCP free-tier badges | AWS Skill Builder, Cloud Skills Boost | varies | Completion badges free |
-| FEMA IS course certificates | FEMA / CISA | 2–4h each | Real gov certificates, great for GRC résumés |
-| Google Cybersecurity Certificate | Coursera | 25h+ | **Free via Financial Aid** — apply, wait ~15 days, commonly approved |
-| TryHackMe path certificates | TryHackMe | varies | Free rooms give completion certs |
+| Networking Basics (badge) | Cisco Networking Academy | 20h | Gratuito de verdade, nome com peso |
+| Intro to Cybersecurity (badge) | Cisco Networking Academy | 6h | A melhor primeira vitória para iniciante absoluto |
+| NSE 1 / 2 / 3 | Fortinet | 6h | Autoinstrucional gratuito, badges digitais |
+| Cybersecurity Fundamentals | IBM SkillsBuild | 15h | Badge gratuito, com labs práticos |
+| Conquistas do Microsoft Learn | Microsoft | varia | O *aprendizado* é gratuito; o **exame** é pago |
+| Badges do tier gratuito AWS / GCP | AWS Skill Builder, Google Skills | varia | Badges de conclusão são gratuitos |
+| Certificados dos cursos FEMA IS | FEMA / CISA | 2–4h cada | Certificados governamentais reais, ótimos para currículo de GRC |
+| Google Cybersecurity Certificate | Coursera | 25h+ | **Gratuito via Financial Aid** — solicite, espere ~15 dias; a aprovação é comum |
+| Certificados de trilha da TryHackMe | TryHackMe | varia | As salas gratuitas geram certificado de conclusão |
 
-⚠️ **Gone:** the ISC2 free CC program (course + exam) **closed on 20 May 2026** after hitting 1 million enrollments. Existing unexpired codes can still be used until 31 Dec 2026, but new sign-ups are closed — CC is now a paid exam. Don't follow older roadmaps that list it as free.
+⚠️ **Acabou:** o programa gratuito do **ISC2 CC** (curso + exame) **encerrou em 20 de maio de 2026**, depois de atingir 1 milhão de inscritos. Códigos já emitidos e não expirados valem até 31/12/2026, mas as novas inscrições estão fechadas — o CC agora é exame pago. **Não siga roadmaps antigos que ainda listam o CC como gratuito.**
 
 ---
 
-## 💳 Paid Lane — when to actually spend money
+## 💳 Faixa paga — quando realmente vale gastar
 
-Order matters. Buy these *in this sequence*, and only when the trigger is met.
+A ordem importa. Compre **nesta sequência**, e só quando o gatilho for atingido.
 
-| Order | Exam | Approx. cost | Buy it when… | Money-saving tips |
+| Ordem | Exame | Custo aprox. | Compre quando… | Como economizar |
 |---|---|---|---|---|
-| 1 | **CompTIA Security+** | ~$400 | You finish Phase 1 and hit 85% on free practice tests | Study 100% free with Professor Messer. Buy the voucher only via a **CompTIA Academic/student discount** or a **bundle sale** (Black Friday, back-to-school). Ask your employer — most L&D budgets cover it. Free retake bundles are worth ~$50 extra if you're unsure. |
-| 2 | **ISC2 CC** | check isc2.org (now paid) | Only if a job posting explicitly names it | Lower value now the free program ended. Skip if you already have Security+. |
-| 3 | **eJPT (INE)** | ~$250 | After PortSwigger + THM Jr Pentester (Phase 2B) | Watch for INE Black Friday deals — sometimes 50%+ off. Entry-level and practical, good first offensive cert. |
-| 4 | **Cloud cert: AZ-500 / SC-200 / AWS Security Specialty** | ~$165–300 | After Phase 2C | **Microsoft gives free/discounted exam vouchers** for attending Virtual Training Days — always check before buying. AWS gives a 50% retake/discount voucher after passing any AWS exam. |
-| 5 | **BTL1 (Security Blue Team)** | ~£400 | After Phase 2A + 3, if you're going SOC | Frequently discounted; strong hands-on reputation for blue team. |
-| 6 | **PNPT (TCM Security)** | ~$500 | Phase 3, red team route | Includes course material — best value in offensive certs. Watch for bundle sales. |
-| 7 | **CISSP / CISM / CRISC** | $600–800 | Only at 3–5 years experience | Don't touch these early — they require verified experience. |
+| 1 | **CompTIA Security+** | ~US$ 400 | Você terminar a Fase 1 e bater 85% em simulados gratuitos | Estude 100% grátis com o Professor Messer. Compre o voucher só via **desconto acadêmico/estudante da CompTIA** ou em **promoção de bundle** (Black Friday, volta às aulas). Pergunte ao seu empregador — a maioria dos orçamentos de treinamento cobre. O bundle com retake grátis custa ~US$ 50 a mais e vale a pena se você estiver insegura ou inseguro. |
+| 2 | **ISC2 CC** | consulte isc2.org (agora pago) | Só se uma vaga citar explicitamente | Perdeu valor desde que o programa gratuito acabou. Pule se você já tem Security+. |
+| 3 | **eJPT (INE)** | ~US$ 250 | Depois do PortSwigger + THM Jr Pentester (Fase 2B) | Fique de olho na Black Friday da INE — às vezes passa de 50% off. É de entrada e prático: boa primeira certificação ofensiva. |
+| 4 | **Certificação de cloud: AZ-500 / SC-200 / AWS Security Specialty** | ~US$ 165–300 | Depois da Fase 2C | A **Microsoft dá vouchers gratuitos ou com desconto** para quem participa dos Virtual Training Days — sempre confira antes de comprar. A AWS dá voucher de 50% de desconto ou retake depois que você passa em qualquer exame deles. |
+| 5 | **BTL1 (Centri, ex-Security Blue Team)** | ~£399 | Depois da Fase 2A + 3, se você vai para SOC | Aparece em promoção com frequência; reputação forte de conteúdo hands-on para blue team. |
+| 6 | **PNPT (TCM Security)** | ~US$ 500 | Fase 3, rota red team | Inclui o material do curso — melhor custo-benefício entre as certificações ofensivas. Fique de olho nos bundles. |
+| 7 | **CISSP / CISM / CRISC** | US$ 600–800 | Só com 3–5 anos de experiência | Não encoste nessas cedo — elas exigem experiência comprovada. |
 
-### Universal money tips
+### Dicas universais de economia
 
-1. **Never pay for a course when the exam is the only thing you need.** Every exam above can be studied for free.
-2. **Employer reimbursement** is the single biggest lever — ask before you pay.
-3. **Black Friday / Cyber Monday** (late Nov) is when INE, TCM, HTB, and Security Blue Team discount hardest. Time your Phase 2→3 transition to land near it.
-4. **Student status** (even a community college class) unlocks CompTIA academic pricing and free GitHub Student Pack perks.
-5. **Free retake insurance** is usually worth it on your first-ever cert exam only.
-6. **Veterans / unemployed programs**: CompTIA, ISC2, and SANS all run periodic subsidised access programs — check eligibility.
+1. **Nunca pague por um curso quando só o exame é necessário.** Todo exame da tabela acima pode ser estudado de graça.
+2. **Reembolso pelo empregador** é a maior alavanca de todas — pergunte antes de pagar.
+3. **Black Friday / Cyber Monday** (fim de novembro) é quando INE, TCM, HTB e Centri dão os maiores descontos. Planeje a transição Fase 2 → 3 para cair perto disso.
+4. **Status de estudante** (até uma disciplina em faculdade pública ou curso técnico) libera o preço acadêmico da CompTIA e as vantagens do GitHub Student Pack.
+5. **Seguro de retake** normalmente só vale a pena no seu primeiro exame de certificação.
+6. **Programas para veteranos / desempregados**: CompTIA, ISC2 e SANS mantêm programas periódicos de acesso subsidiado — verifique se você se encaixa.
+
 
 ---
 
@@ -52,4 +55,3 @@ Order matters. Buy these *in this sequence*, and only when the trigger is met.
 [⬅️ Voltar ao índice](../README.md)
 
 ---
-


### PR DESCRIPTION
Os dois arquivos estavam em inglês num repositório que é PT-BR de ponta a
ponta, e ambos são apontados pelo README como leitura inicial: o roadmap é
o passo 2 do "Começar agora", e certificacoes.md é o destino de "quer saber
o que vale pagar".

O ROADMAP.md ainda era pior que só estar em inglês: os primeiros 80% em
inglês e os últimos 20% em português, sem transição.

Traduzido: títulos, texto corrido, rótulos de tabela e os termos de
estrutura ("Exit test" -> "Teste de saída", "FREE/PAID LANE" -> "FAIXA
GRATUITA/PAGA"). Nomes de cursos, plataformas e certificações ficam no
original, porque é assim que a pessoa vai encontrá-los.

Também corrige dois fatos defasados em certificacoes.md, encontrados na
verificação: o BTL1 é da Centri desde o rebrand de junho/2026 (era
Security Blue Team) e custa ~£399; e "Cloud Skills Boost" virou Google
Skills.

Nenhuma URL foi perdida na reescrita — conferido por diff do conjunto de
links antes e depois.
