### PR TITLE
chore: adiciona verificação automática de links e guia de contribuição

### DIFF
--- a/.github/ISSUE_TEMPLATE/link-quebrado.yml
+++ b/.github/ISSUE_TEMPLATE/link-quebrado.yml
@@ -1,0 +1,40 @@
+name: 🔗 Link quebrado
+description: Um link do catálogo dá 404, ou o curso saiu do ar / virou pago
+title: "🔗 Link quebrado: "
+labels: ["link-quebrado"]
+body:
+  - type: input
+    id: arquivo
+    attributes:
+      label: Arquivo e linha
+      description: Ex. `cursos/02-blue-team.md:14`
+      placeholder: "cursos/00-fundamentos.md:12"
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: URL que está no repositório
+    validations:
+      required: true
+  - type: dropdown
+    id: tipo
+    attributes:
+      label: O que acontece ao abrir?
+      options:
+        - 404 / página não existe
+        - Redireciona para outro lugar (a página original sumiu)
+        - A página abre, mas o curso agora é pago
+        - O domínio inteiro mudou
+        - Outro
+    validations:
+      required: true
+  - type: input
+    id: substituto
+    attributes:
+      label: URL correta, se você souber
+      description: Deixe em branco se não souber — achar o substituto também é contribuição.
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Mais alguma coisa?

--- a/.github/ISSUE_TEMPLATE/sugerir-material.yml
+++ b/.github/ISSUE_TEMPLATE/sugerir-material.yml
@@ -1,0 +1,62 @@
+name: ➕ Sugerir curso, livro ou lab
+description: Indicar material novo para o catálogo
+title: "➕ Sugestão: "
+labels: ["sugestão"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Antes de abrir: os critérios estão em [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
+        Material em **português** é especialmente bem-vindo.
+  - type: input
+    id: nome
+    attributes:
+      label: Nome do material
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: URL direta
+      description: A página do curso em si, não a home do provedor.
+    validations:
+      required: true
+  - type: dropdown
+    id: onde
+    attributes:
+      label: Em que arquivo entraria?
+      options:
+        - cursos/ (curso ou formação)
+        - labs/ (plataforma prática, CTF, wargame)
+        - livros/ (livro ou material de leitura)
+        - repositorios/ (ferramenta ou repo de conhecimento)
+        - recursos/ (canal, podcast, newsletter, comunidade)
+        - Não sei
+    validations:
+      required: true
+  - type: dropdown
+    id: gratuidade
+    attributes:
+      label: É gratuito?
+      options:
+        - Totalmente gratuito
+        - Camada gratuita substancial (diga o que é grátis abaixo)
+        - Pago (só para livros/pagos.md ou a faixa paga de certificações)
+    validations:
+      required: true
+  - type: checkboxes
+    id: criterios
+    attributes:
+      label: Confirmações
+      options:
+        - label: Não é material pirateado — é distribuição autorizada pelo autor ou instituição
+          required: true
+        - label: Eu abri o link e ele funciona
+          required: true
+  - type: textarea
+    id: porque
+    attributes:
+      label: Por que vale entrar?
+      description: Uma ou duas frases. O que ele ensina que o catálogo ainda não cobre?
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## O que muda
+
+<!-- Uma ou duas frases. -->
+
+## Checklist
+
+- [ ] Se adicionei material: passa nos [três critérios](../blob/main/CONTRIBUTING.md#os-três-critérios)
+- [ ] O link aponta para a **página do curso**, não para a home do provedor
+- [ ] Abri o link no navegador e ele funciona
+- [ ] As tags (`🇧🇷` `🇺🇸` `🆓` `💸` `🎓` `🧪` `⭐`) estão coerentes com a [legenda](../blob/main/CONTRIBUTING.md#legenda-das-tags)
+- [ ] Se adicionei host em `.lycheeignore`: incluí o comentário explicando por quê

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,53 @@
+name: Verificação de links
+
+on:
+  schedule:
+    # Segunda-feira, 09:00 UTC (06:00 em Brasília)
+    - cron: "0 9 * * 1"
+  pull_request:
+    paths:
+      - "**.md"
+      - ".lycheeignore"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Testar todos os links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # O .lycheeignore é lido automaticamente do diretório de trabalho —
+          # não passe --exclude-file, que está depreciado e já foi removido
+          # do master do lychee.
+          #
+          # --user-agent: sem ele, university.recordedfuture.com devolve 403.
+          #   Não resolve o OffSec, que devolve 307 com qualquer user-agent —
+          #   por isso 307 está no --accept, e não no .lycheeignore.
+          # --accept: 429 é rate limit (TryHackMe) e 307 é redirect de bot
+          #   detection. Nenhum dos dois é link morto. 404 continua falhando.
+          args: >-
+            --no-progress
+            --max-concurrency 8
+            --timeout 25
+            --max-retries 2
+            --accept 200..=299,307,429
+            --user-agent "Mozilla/5.0 (compatible; Fursec link-check; +https://github.com/${{ github.repository }})"
+            './**/*.md'
+          output: lychee-report.md
+
+      # No agendamento semanal não há PR para reportar: abre/atualiza uma issue.
+      - name: Abrir issue quando algo quebrar
+        if: failure() && github.event_name == 'schedule'
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "🔗 Links quebrados encontrados na verificação semanal"
+          content-filepath: lychee-report.md
+          labels: link-quebrado, manutenção

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 credentials*
 venv/
 __pycache__/
+
+# Worktrees criados pelo harness
+.claude/worktrees/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,27 @@
+# Hosts que NÃO dá para verificar automaticamente.
+#
+# Critério estrito para entrar aqui: o host devolve o MESMO resultado para um
+# caminho válido e para um caminho inventado. Se ele devolve 404 para caminho
+# inexistente, ele é verificável e NÃO entra — senão a gente perde de graça a
+# única proteção contra link morto naquele host.
+#
+# Rate limit (429) e redirect de bot (307) não entram: o workflow trata com
+# `--accept`. Instabilidade momentânea também não: `--max-retries` cobre.
+#
+# Cada entrada foi medida par-a-par (caminho real vs. inventado) em ago/2026.
+# Revise a cada 6 meses: WAF muda, e host que voltou a ser verificável deve sair.
+
+# Cloudflare WAF — 403 para /cursos/linux-fundamentos/ e para /cursos/zzz-nada/
+^https://www\.eucapacito\.com\.br/
+
+# Cloudflare com desafio JS ("Just a moment...") — 403 em qualquer caminho
+^https://www\.mentebinaria\.com\.br/
+
+# 403 para qualquer requisição sem navegador real, em qualquer caminho
+^https://labex\.io/
+^https://www\.iso\.org/
+
+# Origem devolvendo 502 em TODOS os caminhos, inclusive inventados, desde
+# ago/2026. O site é legítimo (Oracle); o servidor deles é que está quebrado.
+# Remover desta lista assim que voltar a responder.
+^https://www\.virtualbox\.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contribuindo com o Fursec
+
+Obrigado por querer ajudar. O Fursec é um catálogo curado — o valor dele está no que **não** entra, tanto quanto no que entra.
+
+---
+
+## Os três critérios
+
+Toda sugestão de curso, livro, lab ou canal precisa passar por estes três:
+
+1. **Gratuito de verdade.** Ou com uma camada gratuita substancial — e marcada como tal. "Grátis por 7 dias" não é gratuito. "Grátis para assistir, pago para o certificado" é, desde que a tag diga isso.
+2. **Nada de material pirateado.** Todo link gratuito tem que ser distribuição autorizada pelo autor ou pela instituição. Se você não consegue apontar onde o autor liberou, não entra.
+3. **Conteúdo em português é especialmente bem-vindo.** É onde a área tem menos material bom e organizado — e é o motivo de este repositório existir em PT-BR.
+
+---
+
+## Como adicionar uma linha
+
+Os catálogos são tabelas markdown. Copie o formato do arquivo em que você está mexendo — ele varia por pasta.
+
+**`cursos/*.md`** — 4 colunas:
+
+```markdown
+| Nome do curso | [Provedor](https://example.com/cursos/nome-do-curso) | 🇧🇷 | 🆓 🎓 |
+```
+
+**`labs/blue-team.md` e `labs/red-team-ctf.md`** — 4 colunas, com nota:
+
+```markdown
+| [Nome da plataforma](https://example.com/) | 🇺🇸 | 🆓 tier 🧪 | Uma linha dizendo o que a torna útil |
+```
+
+### Legenda das tags
+
+| Tag | Significa |
+|---|---|
+| `🇧🇷` / `🇺🇸` | Idioma do conteúdo. Use os dois se houver legenda ou versão dublada. |
+| `🆓` | Gratuito |
+| `💸` | Pago |
+| `🎓` | Emite certificado ou badge |
+| `🧪` | Prático (lab, CTF, ambiente hands-on) |
+| `⭐` | Prioridade alta — use com parcimônia, é o que a pessoa faz primeiro |
+
+Qualificadores que acompanham o `🆓` quando a gratuidade tem ressalva: `parcial`, `tier`, `audit`, `via Financial Aid`.
+
+### Regras de link
+
+- **Aponte para a página do curso, não para a home do provedor.** `provedor.com/cursos/nome-do-curso` em vez de `provedor.com`. Um link genérico obriga a pessoa a caçar.
+- **Sem texto de link genérico.** Nada de `[link]`, `[aqui]`, `[clique]` — use o nome do domínio ou do provedor.
+- **Teste antes de mandar.** Muitos sites de curso devolvem 403 para automação; se o seu link cair nessa, diga no PR que você abriu no navegador e funcionou.
+- **⭐ prioridade alta** é para o que você recomendaria a alguém com 5h por semana. Se tudo é prioridade, nada é.
+
+---
+
+## Verificação automática de links
+
+Todo PR que toca em `.md` dispara a [verificação de links](.github/workflows/link-check.yml). Ela também roda toda segunda-feira e abre uma issue se algo quebrou.
+
+Rate limit (429) e redirect de bot detection (307) são aceitos pelo próprio check — não precisam de exceção.
+
+O [`.lycheeignore`](.lycheeignore) é só para hosts que **não dá para verificar**: aqueles que devolvem o mesmo resultado para um caminho válido e para um inventado, então nenhuma automação consegue distinguir link vivo de link morto. Antes de adicionar um host ali, meça o par: se o caminho inventado devolver 404, o host **é** verificável e não entra — colocá-lo na lista desligaria a única proteção que aquele host teria. Se entrar mesmo, escreva o comentário com a medição.
+
+---
+
+## Convenções de arquivo
+
+Se você criar ou editar um arquivo `.md`:
+
+- Começa com um `# H1` e um `[⬅️ Voltar ao índice](../README.md)` logo abaixo
+- Termina com `---`, linha em branco, e o mesmo link de volta
+- Réguas horizontais (`---`) sempre com linha em branco antes e depois
+- Uma linha em branco no fim do arquivo, nunca duas
+- Catálogos com coluna `Tags` levam a linha de legenda `<sub>` acima da primeira tabela
+
+---
+
+## Abrindo uma issue
+
+- **Link quebrado ou curso que saiu do ar** → use o template de link quebrado. Diga o arquivo, a linha e o que você viu ao abrir.
+- **Sugerir material novo** → use o template de sugestão. Ele pergunta pelos três critérios acima.
+
+Se você já sabe qual é a correção, um PR é mais rápido que uma issue.
+
+---
+
+## O que provavelmente não entra
+
+- Curso pago sem camada gratuita real (a exceção é [`livros/pagos.md`](livros/pagos.md) e a faixa paga de [`docs/certificacoes.md`](docs/certificacoes.md), que são explicitamente sobre gastar dinheiro)
+- Conteúdo atrás de cadastro que exige CNPJ ou e-mail corporativo, sem alternativa
+- Mais uma awesome-list genérica — [`repositorios/awesome-lists.md`](repositorios/awesome-lists.md) já cobre os índices mestres
+- Ferramenta ofensiva sem contexto de uso legítimo e defensivo


### PR DESCRIPTION
Acabamos de corrigir dezenas de links mortos à mão. São 276 links externos,
e o repositório aponta muito para startup de treinamento (domínio que muda)
e curso gratuito (que sai do ar). Sem automação isso volta.

O que entra:
- `.github/workflows/link-check.yml` — lychee toda segunda e em cada PR que
  toca `.md`; no agendamento semanal abre uma issue com o relatório
- `.lycheeignore` — a lista de exceções, com critério estrito
- `CONTRIBUTING.md` — critérios de curadoria e formato das tabelas
- templates de issue ("link quebrado", "sugerir material") e de PR

Decisões de projeto que importam:

429 e 307 são aceitos, não ignorados. Rate limit (TryHackMe) e redirect de
bot detection (OffSec) não são link morto. Colocá-los no ignore desligaria a
detecção de 404 nesses hosts; aceitá-los no `--accept` preserva.

O user-agent não é cosmético. Sem ele, university.recordedfuture.com devolve
403 (medido: 403 com UA do lychee, 200 com o configurado). Um CI cronicamente
vermelho é um CI que ninguém olha.

O `.lycheeignore` tem critério estrito e medido: só entra host que devolve o
mesmo resultado para caminho válido e para caminho inventado — ou seja, onde
nenhuma automação distingue vivo de morto. Cada entrada foi medida par-a-par.
Isso deixou de fora o sourceforge.net, que numa medição anterior parecia
bloquear tudo mas na verdade responde 200 para /projects/metasploitable/ e
404 para caminho inventado: é verificável, e ignorá-lo desligaria a única
proteção do único link que o repositório tem nesse host.

Entram 5 hosts: eucapacito, mentebinaria, labex.io e iso.org (403 em
qualquer caminho) e virtualbox.org (origem devolvendo 502 em todo caminho,
inclusive inventado, desde ago/2026 — com nota para remover quando voltar).

Não passamos `--exclude-file`: a flag está depreciada e já foi removida do
master do lychee, e o `.lycheeignore` é lido automaticamente do diretório de
trabalho. Como a action aceita `lycheeVersion: latest`, usá-la seria quebra
futura garantida.

Os links dos templates usam a forma `../blob/main/...`: o GitHub não reescreve
link relativo em corpo de PR ou issue, então `../CONTRIBUTING.md` resolveria
para /owner/repo/CONTRIBUTING.md e daria 404.
