### PR TITLE
fix(site): páginas de pasta deixam de ser órfãs e de cair no GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/docs/metodo-de-estudo.md">Método de estudo</a><span>Como estudar para reter. Leia antes de tudo.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/ROADMAP.md">Roadmap</a><span>Cinco fases medidas em horas, não em datas.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/docs/trilha-pt-br.md">Trilha só em português</a><span>A trilha inteira, do zero, sem inglês.</span></li>
+  </ul>
+</section>
+
+<section>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/progresso/README.md">Progresso</a></h2>
+  <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/progresso/checklist.md">Checklist</a><span>Marque o que concluiu, com data.</span></li>
   </ul>
 </section>
@@ -41,7 +47,7 @@
 </section>
 
 <section>
-  <h2>Cursos</h2>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/cursos/README.md">Cursos</a></h2>
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/cursos/00-fundamentos.md">Fundamentos</a><span>TI, redes, sistemas e programação.</span>
       <ul class="sec">
@@ -60,7 +66,7 @@
 </section>
 
 <section>
-  <h2>Labs</h2>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/labs/README.md">Labs</a></h2>
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/labs/home-lab.md">Home lab barato</a><span>Do R$ 0 ao mini servidor dedicado.</span>
       <ul class="sec">
@@ -84,7 +90,7 @@
 </section>
 
 <section>
-  <h2>Projetos</h2>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/projetos/README.md">Projetos</a></h2>
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/projetos/00-regras.md">Regras de ética</a><span>Obrigatório antes de qualquer projeto.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/projetos/01-fundamentais.md">P1–P4 fundamentais</a><span>Home lab, ferramentas em Python, hardening.</span>
@@ -144,12 +150,12 @@
         <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/projetos/06-appsec.md#p33--code-review-de-segurança-com-pr-real">P33 — Code review de segurança com PR real</a></li>
       </ul>
     </li>
-    <li><a href="https://github.com/bunnyiesart/Fursec/tree/main/projetos/templates">Templates</a><span>README de projeto, writeup de CTF, relatório.</span></li>
+    <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/projetos/README.md#-templates-prontos">Templates</a><span>README de projeto, writeup de CTF, relatório.</span></li>
   </ul>
 </section>
 
 <section>
-  <h2>Repositórios</h2>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/repositorios/README.md">Repositórios</a></h2>
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/repositorios/awesome-lists.md">Awesome lists</a><span>Os índices mestres.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/repositorios/conhecimento.md">Consulta diária</a><span>HackTricks, PayloadsAllTheThings, SecLists.</span></li>
@@ -161,7 +167,7 @@
 </section>
 
 <section>
-  <h2>Livros</h2>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/livros/README.md">Livros</a></h2>
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/livros/gratuitos-pt.md">Gratuitos em português</a><span>Distribuição autorizada, nada pirata.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/livros/gratuitos-en.md">Gratuitos em inglês</a><span>Security Engineering, CyBOK, OWASP.</span></li>
@@ -170,7 +176,7 @@
 </section>
 
 <section>
-  <h2>Documentação</h2>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/docs/README.md">Documentação</a></h2>
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/docs/metodo-de-estudo.md">Método de estudo</a><span>Active recall, Anki, as 7 armadilhas.</span>
       <ul class="sec">
@@ -210,7 +216,7 @@
 </section>
 
 <section>
-  <h2>Recursos e progresso</h2>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/recursos/README.md">Recursos</a></h2>
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/recursos/youtube.md">Canais de YouTube</a><span>Brasileiros e internacionais.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/recursos/podcasts-comunidades.md">Podcasts e comunidades</a><span>Newsletters, eventos, fóruns.</span></li>

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -81,10 +81,13 @@ def reescreve(corpo, caminho):
                 return f'href="{subir or "./"}index.html{frag}"'
         if arq.endswith(".md"):
             return f'href="{arq[:-3]}.html{frag}"'
-        # Relativo para algo que não é .md (workflow, .lycheeignore, pasta):
-        # esses arquivos não existem no site. Aponta para o GitHub, senão
-        # viraria link quebrado.
         resolvido = os.path.normpath(os.path.join(os.path.dirname(caminho), arq))
+        # Link para pasta: no site quem faz esse papel é o README dela.
+        if os.path.isdir(os.path.join(RAIZ, resolvido)) and \
+           os.path.exists(os.path.join(RAIZ, resolvido, "README.md")):
+            return f'href="{arq.rstrip("/")}/README.html{frag}"'
+        # Relativo para algo que não é .md nem pasta com índice (workflow,
+        # .lycheeignore): não existe no site, então aponta para o GitHub.
         return f'href="https://github.com/{REPO}/blob/main/{resolvido}{frag}"'
 
     corpo = re.sub(r'href="([^"]+)"', link, corpo)

--- a/tools/check-site.py
+++ b/tools/check-site.py
@@ -2,10 +2,13 @@
 """Confere os links internos do site gerado.
 
 Não toca em link externo — disso cuida o workflow de verificação de links.
-Aqui o alvo é o que o build pode quebrar sozinho: página que não existe e,
-principalmente, âncora que aponta para um id inexistente. Âncora quebrada
-devolve 200 e leva a pessoa para o topo em silêncio, então nenhum verificador
-de status pega.
+Aqui o alvo é o que o build pode quebrar sozinho:
+
+- página que não existe;
+- âncora que aponta para um id inexistente (devolve 200 e leva ao topo em
+  silêncio, então nenhum verificador de status pega);
+- página gerada que ninguém alcança a partir do índice. Órfã não aparece
+  para quem navega nem para buscador, e é invisível num teste de links.
 
 Uso:
     python3 tools/check-site.py [_site]
@@ -52,10 +55,30 @@ def main():
             elif frag and frag not in ids.get(alvo, set()):
                 problemas.append(f"{p}: âncora inexistente -> {href}")
 
+    # Alcançabilidade: navega a partir do índice e vê o que sobra.
+    inicio = os.path.normpath(os.path.join(raiz, "index.html"))
+    alcancadas, fila = set(), [inicio]
+    while fila:
+        atual = fila.pop()
+        if atual in alcancadas or not os.path.exists(atual):
+            continue
+        alcancadas.add(atual)
+        base = os.path.dirname(atual)
+        for href in HREF.findall(open(atual, encoding="utf-8").read()):
+            if href.startswith(("http://", "https://", "mailto:", "data:", "#")):
+                continue
+            alvo = os.path.normpath(
+                os.path.join(base, urllib.parse.unquote(href.split("#")[0])))
+            if alvo.endswith(".html"):
+                fila.append(alvo)
+    orfas = sorted(set(map(os.path.normpath, paginas)) - alcancadas)
+    problemas += [f"{o}: página órfã, não se chega nela a partir do índice"
+                  for o in orfas]
+
     for x in problemas:
         print(f"::error::{x}")
     print(f"{total} links internos verificados em {len(paginas)} páginas; "
-          f"{len(problemas)} quebrado(s)")
+          f"{len(alcancadas)} alcançáveis; {len(problemas)} problema(s)")
     return 1 if problemas else 0
 
 


### PR DESCRIPTION
Varrendo o site publicado, dois defeitos apareceram — e eram o mesmo:

O ROADMAP linka para as pastas (`./cursos/`, `./projetos/`). A regra do build
mandava todo link não-.md para o GitHub, então esses dois saíam do site. Mas
as pastas TÊM página aqui: é o README delas. Agora link de pasta aponta para
`<pasta>/README.html` quando esse arquivo existe.

Consequência disso: 7 das 49 páginas geradas eram órfãs — os README de
`cursos/`, `docs/`, `labs/`, `livros/`, `progresso/`, `recursos/` e
`repositorios/`. Ninguém chegava neles navegando, e eles têm conteúdo que não
está no índice (o "loop correto" de lab, "se você só puder ler três", a nota
dos 5% de tempo em notícia). Página órfã não aparece para quem navega nem
para buscador.

Corrigir o link de pasta conectou dois. Para os outros, o título de cada
seção do índice virou link para a página-índice daquela pasta. "Recursos e
progresso" era um título cobrindo duas pastas e virou duas seções.

Agora: 49 de 49 alcançáveis a partir do índice, zero órfã.

Sobram 4 links apontando para o GitHub, todos corretos: o `.lycheeignore` e
o workflow citados no CONTRIBUTING (arquivos que não existem como página) e
o link do repositório no cabeçalho e no rodapé. O item "Templates", que
apontava para uma listagem de diretório, passou a levar à seção
correspondente na página de projetos.

O validador ganhou detecção de órfã: ele navegava a partir do índice? Não —
só conferia se cada link resolvia, o que não pega página que ninguém linka.
Agora percorre o site a partir do índice e falha se sobrar página inalcançada.
Testado nos dois sentidos.
