### PR TITLE
fix(site): imagem de fundo volta a aparecer; conserta seções do índice

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -72,6 +72,13 @@ h2 {
   text-transform: uppercase;
 }
 
+/* Título de seção que leva à página-índice da pasta: herda a cor do
+   próprio título, senão vira azul de link e quebra a paleta. */
+section > h2 a { color: inherit; text-decoration: none;
+  border-bottom: 1px solid transparent; }
+section > h2 a:hover, section > h2 a:focus {
+  color: var(--accent); border-bottom-color: var(--accent); outline: none; }
+
 /* Lista de links */
 ul { margin: 0; padding: 0; list-style: none; }
 li { padding: .3rem 0; }
@@ -113,7 +120,7 @@ li span {
    Decorativo — por isso é background em CSS e não <img>: leitor de tela
    ignora, em vez de anunciar a descrição no meio da navegação.
    A opacidade é o único número que importa aqui; mexa nela à vontade. */
-body::before {
+body.inicio::before {
   content: "";
   position: fixed;
   /* mais alto que a janela: a folga de 15% em cima e embaixo é exatamente
@@ -121,7 +128,9 @@ body::before {
   inset: -15% 0;
   z-index: -1;
   pointer-events: none;
-  background: url("assets/mascote.jpg") no-repeat center 34% / cover;
+  /* Caminho relativo à FOLHA DE ESTILO, não ao documento. Como este arquivo
+     mora em assets/, "assets/mascote.jpg" viraria assets/assets/... */
+  background: url("mascote.jpg") no-repeat center 34% / cover;
   filter: grayscale(.55);
   opacity: .06;
   /* --py é escrito pelo script de parallax; sem script fica 0 e nada se move */
@@ -130,11 +139,11 @@ body::before {
 }
 @media (prefers-color-scheme: dark) {
   /* no escuro quem aparece é o claro da foto, e ele salta mais */
-  body::before { opacity: .08; }
+  body.inicio::before { opacity: .08; }
 }
 /* Quem pediu menos movimento no sistema não recebe parallax. */
 @media (prefers-reduced-motion: reduce) {
-  body::before { transform: none !important; }
+  body.inicio::before { transform: none !important; }
 }
 
 footer {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>🦊</text></svg>">
 <link rel="stylesheet" href="assets/site.css">
 </head>
-<body>
+<body class="inicio">
 
 <h1>Fursec</h1>
 <p class="sub">Trilha de cibersegurança com material gratuito · <a href="https://github.com/bunnyiesart/Fursec">repositório</a></p>
@@ -22,12 +22,6 @@
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/docs/metodo-de-estudo.md">Método de estudo</a><span>Como estudar para reter. Leia antes de tudo.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/ROADMAP.md">Roadmap</a><span>Cinco fases medidas em horas, não em datas.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/docs/trilha-pt-br.md">Trilha só em português</a><span>A trilha inteira, do zero, sem inglês.</span></li>
-  </ul>
-</section>
-
-<section>
-  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/progresso/README.md">Progresso</a></h2>
-  <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/progresso/checklist.md">Checklist</a><span>Marque o que concluiu, com data.</span></li>
   </ul>
 </section>
@@ -220,6 +214,12 @@
   <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/recursos/youtube.md">Canais de YouTube</a><span>Brasileiros e internacionais.</span></li>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/recursos/podcasts-comunidades.md">Podcasts e comunidades</a><span>Newsletters, eventos, fóruns.</span></li>
+  </ul>
+</section>
+
+<section>
+  <h2><a href="https://github.com/bunnyiesart/Fursec/blob/main/progresso/README.md">Progresso</a></h2>
+  <ul>
     <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/progresso/checklist.md">Checklist</a><span>Por fase, com campo de data.</span>
       <ul class="sec">
         <li><a href="https://github.com/bunnyiesart/Fursec/blob/main/progresso/checklist.md#fase-0--fundamentos">Fase 0 — Fundamentos</a></li>

--- a/tools/check-site.py
+++ b/tools/check-site.py
@@ -8,7 +8,10 @@ Aqui o alvo é o que o build pode quebrar sozinho:
 - âncora que aponta para um id inexistente (devolve 200 e leva ao topo em
   silêncio, então nenhum verificador de status pega);
 - página gerada que ninguém alcança a partir do índice. Órfã não aparece
-  para quem navega nem para buscador, e é invisível num teste de links.
+  para quem navega nem para buscador, e é invisível num teste de links;
+- arquivo referenciado por `src=` ou por `url()` dentro de CSS. O url() de
+  uma folha de estilo resolve a partir DELA, não do documento — mover o CSS
+  de lugar quebra a imagem sem quebrar nenhum href.
 
 Uso:
     python3 tools/check-site.py [_site]
@@ -21,6 +24,8 @@ import urllib.parse
 
 HREF = re.compile(r'href="([^"]+)"')
 ID = re.compile(r'id="([^"]+)"')
+SRC = re.compile(r'src="([^"]+)"')
+CSSURL = re.compile(r'url\(\s*["\']?([^"\')]+)["\']?\s*\)')
 
 
 def main():
@@ -55,6 +60,31 @@ def main():
             elif frag and frag not in ids.get(alvo, set()):
                 problemas.append(f"{p}: âncora inexistente -> {href}")
 
+    # Recursos: src= no HTML e url() dentro do CSS. O url() resolve a partir
+    # da folha de estilo, então é fácil quebrar sem perceber ao movê-la.
+    for p in paginas:
+        base = os.path.dirname(p)
+        for src in SRC.findall(open(p, encoding="utf-8").read()):
+            if src.startswith(("http://", "https://", "data:")):
+                continue
+            total += 1
+            alvo = os.path.normpath(os.path.join(base, urllib.parse.unquote(src)))
+            if not os.path.exists(alvo):
+                problemas.append(f"{p}: src inexistente -> {src}")
+
+    for d, _, fs in os.walk(raiz):
+        for f in fs:
+            if not f.endswith(".css"):
+                continue
+            css = os.path.join(d, f)
+            for u in CSSURL.findall(open(css, encoding="utf-8").read()):
+                if u.startswith(("http://", "https://", "data:", "#")):
+                    continue
+                total += 1
+                alvo = os.path.normpath(os.path.join(d, urllib.parse.unquote(u)))
+                if not os.path.exists(alvo):
+                    problemas.append(f"{css}: url() inexistente -> {u}")
+
     # Alcançabilidade: navega a partir do índice e vê o que sobra.
     inicio = os.path.normpath(os.path.join(raiz, "index.html"))
     alcancadas, fila = set(), [inicio]
@@ -77,7 +107,7 @@ def main():
 
     for x in problemas:
         print(f"::error::{x}")
-    print(f"{total} links internos verificados em {len(paginas)} páginas; "
+    print(f"{total} referências internas verificadas em {len(paginas)} páginas; "
           f"{len(alcancadas)} alcançáveis; {len(problemas)} problema(s)")
     return 1 if problemas else 0
 


### PR DESCRIPTION
Três defeitos, todos introduzidos por mim nos dois PRs anteriores.

1. A imagem de fundo estava 404 desde que o CSS saiu do index.html para
   assets/site.css. O `url()` de uma folha de estilo resolve a partir DELA,
   não do documento: como o arquivo mora em assets/, `url("assets/mascote.jpg")`
   virou `assets/assets/mascote.jpg`. Agora é `url("mascote.jpg")`.

   O fundo passa a ficar restrito à página inicial (`body.inicio`). As
   páginas de conteúdo têm texto denso e tabela, onde um rosto atrás
   atrapalha mais do que ajuda. Para valer no site todo, é trocar
   `body.inicio::before` por `body::before` — o script de parallax só existe
   no índice, então nas demais o fundo ficaria parado.

2. A seção "Progresso" do índice foi inserida no lugar errado: caiu logo
   depois de "Comece aqui" e levou junto o item Checklist, que pertencia
   àquele bloco. Reposicionada no fim, junto de "Recursos", e o Checklist
   voltou para "Comece aqui".

3. Os títulos de seção que viraram link ficaram azuis, quebrando a paleta
   monocromática. `section > h2 a` agora herda a cor do título e só muda no
   hover, como os demais links da página.

Os dois últimos passaram porque, no PR anterior, eu validei os links e não
olhei a página renderizada. O validador não pega cor nem ordem de seção.

O primeiro o validador AGORA pega: ele conferia apenas `href`, e por isso
não via imagem quebrada. Passa a conferir também `src=` e `url()` dentro de
CSS. Testado com o bug original reintroduzido de propósito: acusa
`url() inexistente -> assets/mascote.jpg` e sai com código 1.
